### PR TITLE
feat: PubGrub resolver with full deterministic lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ dependencies = [
  "dirs",
  "flate2",
  "indicatif",
+ "pubgrub",
  "rayon",
  "reqwest",
  "serde",
@@ -890,12 +891,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "priority-queue"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
+dependencies = [
+ "equivalent",
+ "indexmap",
+ "serde",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pubgrub"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f5df7e552bc7edd075f5783a87fbfc21d6a546e32c16985679c488c18192d83"
+dependencies = [
+ "indexmap",
+ "log",
+ "priority-queue",
+ "rustc-hash",
+ "thiserror",
+ "version-ranges",
 ]
 
 [[package]]
@@ -987,6 +1013,12 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -1398,6 +1430,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-ranges"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3595ffe225639f1e0fd8d7269dcc05d2fbfea93cfac2fea367daf1adb60aae91"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ clap = { version = "4.5.60", features = ["derive"] }
 dirs = "6.0.0"
 flate2 = "1.1.9"
 indicatif = "0.18.4"
+pubgrub = "0.3.0"
 rayon = "1.11.0"
 reqwest = { version = "0.13.2", features = ["blocking", "native-tls"], default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::version::Dep;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -20,11 +21,25 @@ pub fn read_config() -> ArrrConfig {
     toml::from_str(&text).expect("failed to parse arrrv.toml")
 }
 
-/// Strips version specifier from a dependency string: "ggplot2>=3.4" → "ggplot2"
-pub fn parse_dep_name(dep: &str) -> String {
-    dep.chars()
+/// Parse a dependency string from arrrv.toml into a `Dep`.
+/// Handles formats: "ggplot2", "ggplot2>=3.4", "rlang (>= 1.0)"
+pub fn parse_dep(s: &str) -> Dep {
+    let name: String = s
+        .chars()
         .take_while(|c| c.is_alphanumeric() || *c == '.' || *c == '-')
-        .collect()
+        .collect();
+    // remainder after the name: strip whitespace and optional surrounding parens
+    let rest = s[name.len()..]
+        .trim()
+        .trim_matches(|c| c == '(' || c == ')');
+    let req = crate::version::VersionReq::parse(rest);
+    Dep::new(name, req)
+}
+
+/// Strips version specifier from a dependency string: "ggplot2>=3.4" → "ggplot2"
+/// Kept for callers that only need the name.
+pub fn parse_dep_name(dep: &str) -> String {
+    parse_dep(dep).name
 }
 
 #[cfg(test)]
@@ -68,5 +83,29 @@ mod tests {
     fn test_parse_dep_name_preserves_dots_and_dashes() {
         assert_eq!(parse_dep_name("data.table"), "data.table");
         assert_eq!(parse_dep_name("R6"), "R6");
+    }
+
+    #[test]
+    fn test_parse_dep_no_constraint() {
+        use crate::version::Op;
+        let d = parse_dep("dplyr");
+        assert_eq!(d.name, "dplyr");
+        assert!(d.req.is_none());
+
+        let d2 = parse_dep("ggplot2>=3.4");
+        assert_eq!(d2.name, "ggplot2");
+        let req = d2.req.unwrap();
+        assert!(matches!(req.op, Op::Gte));
+        assert_eq!(req.version, crate::version::RVersion::parse("3.4").unwrap());
+    }
+
+    #[test]
+    fn test_parse_dep_space_constraint() {
+        use crate::version::Op;
+        let d = parse_dep("rlang (>= 1.0)");
+        assert_eq!(d.name, "rlang");
+        let req = d.req.unwrap();
+        assert!(matches!(req.op, Op::Gte));
+        assert_eq!(req.version, crate::version::RVersion::parse("1.0").unwrap());
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,4 +1,5 @@
 use crate::cache::cache_dir;
+use crate::version::Dep;
 use flate2::read::GzDecoder;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -8,7 +9,7 @@ use std::time::Duration;
 #[derive(Serialize, Deserialize)]
 pub struct Package {
     pub version: String,
-    pub deps: Vec<String>,
+    pub deps: Vec<Dep>,
 }
 
 pub fn parse_packages(text: &str) -> HashMap<String, Package> {
@@ -31,7 +32,7 @@ pub fn parse_packages(text: &str) -> HashMap<String, Package> {
 
         let mut name = None;
         let mut version = None;
-        let mut deps: Vec<String> = Vec::new();
+        let mut deps: Vec<Dep> = Vec::new();
 
         for line in joined.lines() {
             if let Some((key, val)) = line.split_once(": ") {
@@ -39,13 +40,18 @@ pub fn parse_packages(text: &str) -> HashMap<String, Package> {
                     "Package" => name = Some(val.to_string()),
                     "Version" => version = Some(val.to_string()),
                     "Imports" | "Depends" => {
-                        for dep in val.split(',') {
-                            let dep_name = dep
-                                .trim()
-                                .split_once(' ')
-                                .map(|(n, _)| n)
-                                .unwrap_or(dep.trim())
-                                .to_string();
+                        for raw in val.split(',') {
+                            let raw = raw.trim();
+                            // split "rlang (>= 1.1.0)" into name and optional constraint
+                            let (dep_name, req) = if let Some((name, rest)) = raw.split_once('(') {
+                                let req = rest.trim_end_matches(')').trim();
+                                (
+                                    name.trim().to_string(),
+                                    crate::version::VersionReq::parse(req),
+                                )
+                            } else {
+                                (raw.to_string(), None)
+                            };
                             let base_packages = [
                                 "R",
                                 "base",
@@ -60,7 +66,7 @@ pub fn parse_packages(text: &str) -> HashMap<String, Package> {
                                 "compiler",
                             ];
                             if !base_packages.contains(&dep_name.as_str()) && !dep_name.is_empty() {
-                                deps.push(dep_name);
+                                deps.push(Dep::new(dep_name, req));
                             }
                         }
                     }
@@ -131,16 +137,30 @@ mod tests {
         let index = parse_packages(text);
         let pkg = index.get("ggplot2").unwrap();
         assert_eq!(pkg.version, "3.5.1");
-        assert!(pkg.deps.contains(&"rlang".to_string()));
-        assert!(pkg.deps.contains(&"scales".to_string()));
+        assert!(pkg.deps.iter().any(|d| d.name == "rlang"));
+        assert!(pkg.deps.iter().any(|d| d.name == "scales"));
     }
 
     #[test]
-    fn test_parse_strips_version_constraints() {
+    fn test_parse_preserves_version_constraints() {
+        use crate::version::{Op, RVersion};
         let text = "Package: foo\nVersion: 1.0\nImports: rlang (>= 1.1.0)\n";
         let index = parse_packages(text);
         let pkg = index.get("foo").unwrap();
-        assert_eq!(pkg.deps, vec!["rlang"]);
+        assert_eq!(pkg.deps.len(), 1);
+        assert_eq!(pkg.deps[0].name, "rlang");
+        let req = pkg.deps[0].req.as_ref().unwrap();
+        assert!(matches!(req.op, Op::Gte));
+        assert_eq!(req.version, RVersion::parse("1.1.0").unwrap());
+    }
+
+    #[test]
+    fn test_parse_dep_without_constraint() {
+        let text = "Package: foo\nVersion: 1.0\nImports: rlang\n";
+        let index = parse_packages(text);
+        let pkg = index.get("foo").unwrap();
+        assert_eq!(pkg.deps[0].name, "rlang");
+        assert!(pkg.deps[0].req.is_none());
     }
 
     #[test]
@@ -148,9 +168,9 @@ mod tests {
         let text = "Package: foo\nVersion: 1.0\nDepends: R (>= 4.0), methods, rlang\n";
         let index = parse_packages(text);
         let pkg = index.get("foo").unwrap();
-        assert!(!pkg.deps.contains(&"R".to_string()));
-        assert!(!pkg.deps.contains(&"methods".to_string()));
-        assert!(pkg.deps.contains(&"rlang".to_string()));
+        assert!(!pkg.deps.iter().any(|d| d.name == "R"));
+        assert!(!pkg.deps.iter().any(|d| d.name == "methods"));
+        assert!(pkg.deps.iter().any(|d| d.name == "rlang"));
     }
 
     #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::time::Duration;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Package {
     pub version: String,
     pub deps: Vec<Dep>,

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -232,7 +232,7 @@ mod tests {
                     name.to_string(),
                     Package {
                         version: version.to_string(),
-                        deps: vec![],
+                        deps: vec![], // no deps needed for URL-building tests
                     },
                 )
             })

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -37,12 +37,13 @@ fn write_lockfile_to(
             out.push_str(&format!("name = \"{}\"\n", name));
             out.push_str(&format!("version = \"{}\"\n", pkg.version));
             if !pkg.deps.is_empty() {
-                let mut sorted_deps = pkg.deps.clone();
-                sorted_deps.sort();
+                let mut sorted_dep_names: Vec<&str> =
+                    pkg.deps.iter().map(|d| d.name.as_str()).collect();
+                sorted_dep_names.sort();
                 // only include deps that are in the resolved package list
-                let resolved_deps: Vec<_> = sorted_deps
-                    .iter()
-                    .filter(|d| packages.contains(d))
+                let resolved_deps: Vec<&str> = sorted_dep_names
+                    .into_iter()
+                    .filter(|d| packages.contains(&d.to_string()))
                     .collect();
                 if !resolved_deps.is_empty() {
                     out.push_str("dependencies = [");
@@ -128,7 +129,7 @@ mod tests {
                     name.to_string(),
                     Package {
                         version: version.to_string(),
-                        deps: vec![],
+                        deps: vec![], // no deps needed for lockfile format tests
                     },
                 )
             })

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -48,6 +48,7 @@ fn write_lockfile_to(
         out.push_str("[[package]]\n");
         out.push_str(&format!("name = \"{}\"\n", name));
         out.push_str(&format!("version = \"{}\"\n", version_str));
+        out.push_str("source = { registry = \"https://cloud.r-project.org\" }\n");
         // write deps that are also in the resolved set
         if let Some(pkg) = index.get(*name)
             && !pkg.deps.is_empty()
@@ -173,6 +174,19 @@ mod tests {
         assert!(contents.contains("[[package]]"));
         assert!(contents.contains("name = \"ggplot2\""));
         assert!(contents.contains("version = \"3.5.1\""));
+    }
+
+    #[test]
+    fn test_write_lockfile_includes_source() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let index = make_index(&[("ggplot2", "3.5.1")]);
+        let resolved = make_resolved(&[("ggplot2", "3.5.1")]);
+        let roots = vec!["ggplot2".to_string()];
+
+        write_lockfile_to(tmp.path(), &roots, &resolved, &index);
+
+        let contents = std::fs::read_to_string(tmp.path()).unwrap();
+        assert!(contents.contains("source = { registry = \"https://cloud.r-project.org\" }"));
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -39,10 +39,15 @@ fn write_lockfile_to(
     sorted_names.sort();
 
     for name in &sorted_names {
-        let version = &resolved[*name];
+        // Use the original version string from the index (preserves dashes e.g. "2.23-26").
+        // Fall back to RVersion Display only if somehow not in the index.
+        let version_str = index
+            .get(*name)
+            .map(|p| p.version.as_str())
+            .unwrap_or_else(|| "0");
         out.push_str("[[package]]\n");
         out.push_str(&format!("name = \"{}\"\n", name));
-        out.push_str(&format!("version = \"{}\"\n", version));
+        out.push_str(&format!("version = \"{}\"\n", version_str));
         // write deps that are also in the resolved set
         if let Some(pkg) = index.get(*name)
             && !pkg.deps.is_empty()
@@ -168,6 +173,22 @@ mod tests {
         assert!(contents.contains("[[package]]"));
         assert!(contents.contains("name = \"ggplot2\""));
         assert!(contents.contains("version = \"3.5.1\""));
+    }
+
+    #[test]
+    fn test_write_lockfile_preserves_dash_version() {
+        // "2.23-26" must not become "2.23.26" — the original string must be preserved
+        // so that download URLs remain valid.
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let index = make_index(&[("nlme", "2.23-26")]);
+        let resolved = make_resolved(&[("nlme", "2.23-26")]);
+        let roots = vec!["nlme".to_string()];
+
+        write_lockfile_to(tmp.path(), &roots, &resolved, &index);
+
+        let contents = std::fs::read_to_string(tmp.path()).unwrap();
+        assert!(contents.contains("version = \"2.23-26\""));
+        assert!(!contents.contains("2.23.26"));
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,17 +1,23 @@
 use crate::index::Package;
+use crate::version::RVersion;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
 
-pub fn write_lockfile(roots: &[String], packages: &[String], index: &HashMap<String, Package>) {
-    write_lockfile_to(Path::new("arrrv.lock"), roots, packages, index);
+/// Write arrrv.lock from the pubgrub-resolved map of package → version.
+pub fn write_lockfile(
+    roots: &[String],
+    resolved: &HashMap<String, RVersion>,
+    index: &HashMap<String, Package>,
+) {
+    write_lockfile_to(Path::new("arrrv.lock"), roots, resolved, index);
     println!("wrote arrrv.lock");
 }
 
 fn write_lockfile_to(
     path: &Path,
     roots: &[String],
-    packages: &[String],
+    resolved: &HashMap<String, RVersion>,
     index: &HashMap<String, Package>,
 ) {
     let mut sorted_roots = roots.to_vec();
@@ -29,36 +35,38 @@ fn write_lockfile_to(
     );
     out.push_str("]\n\n");
 
-    let mut sorted = packages.to_vec();
-    sorted.sort();
-    for name in &sorted {
-        if let Some(pkg) = index.get(name) {
-            out.push_str("[[package]]\n");
-            out.push_str(&format!("name = \"{}\"\n", name));
-            out.push_str(&format!("version = \"{}\"\n", pkg.version));
-            if !pkg.deps.is_empty() {
-                let mut sorted_dep_names: Vec<&str> =
-                    pkg.deps.iter().map(|d| d.name.as_str()).collect();
-                sorted_dep_names.sort();
-                // only include deps that are in the resolved package list
-                let resolved_deps: Vec<&str> = sorted_dep_names
-                    .into_iter()
-                    .filter(|d| packages.contains(&d.to_string()))
-                    .collect();
-                if !resolved_deps.is_empty() {
-                    out.push_str("dependencies = [");
-                    out.push_str(
-                        &resolved_deps
-                            .iter()
-                            .map(|d| format!("{{ name = \"{}\" }}", d))
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                    );
-                    out.push_str("]\n");
-                }
+    let mut sorted_names: Vec<&String> = resolved.keys().collect();
+    sorted_names.sort();
+
+    for name in &sorted_names {
+        let version = &resolved[*name];
+        out.push_str("[[package]]\n");
+        out.push_str(&format!("name = \"{}\"\n", name));
+        out.push_str(&format!("version = \"{}\"\n", version));
+        // write deps that are also in the resolved set
+        if let Some(pkg) = index.get(*name)
+            && !pkg.deps.is_empty()
+        {
+            let mut sorted_dep_names: Vec<&str> =
+                pkg.deps.iter().map(|d| d.name.as_str()).collect();
+            sorted_dep_names.sort();
+            let resolved_deps: Vec<&str> = sorted_dep_names
+                .into_iter()
+                .filter(|d| resolved.contains_key(*d))
+                .collect();
+            if !resolved_deps.is_empty() {
+                out.push_str("dependencies = [");
+                out.push_str(
+                    &resolved_deps
+                        .iter()
+                        .map(|d| format!("{{ name = \"{}\" }}", d))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
+                out.push_str("]\n");
             }
-            out.push('\n');
         }
+        out.push('\n');
     }
     std::fs::write(path, out).unwrap();
 }
@@ -120,6 +128,7 @@ struct Manifest {
 mod tests {
     use super::*;
     use crate::index::Package;
+    use crate::version::RVersion;
 
     fn make_index(entries: &[(&str, &str)]) -> HashMap<String, Package> {
         entries
@@ -136,14 +145,21 @@ mod tests {
             .collect()
     }
 
+    fn make_resolved(entries: &[(&str, &str)]) -> HashMap<String, RVersion> {
+        entries
+            .iter()
+            .map(|(name, version)| (name.to_string(), RVersion::parse(version).unwrap()))
+            .collect()
+    }
+
     #[test]
     fn test_write_lockfile_format() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let index = make_index(&[("ggplot2", "3.5.1"), ("rlang", "1.1.4")]);
+        let resolved = make_resolved(&[("ggplot2", "3.5.1"), ("rlang", "1.1.4")]);
         let roots = vec!["ggplot2".to_string()];
-        let packages = vec!["ggplot2".to_string(), "rlang".to_string()];
 
-        write_lockfile_to(tmp.path(), &roots, &packages, &index);
+        write_lockfile_to(tmp.path(), &roots, &resolved, &index);
 
         let contents = std::fs::read_to_string(tmp.path()).unwrap();
         assert!(contents.contains("version = 1"));
@@ -158,10 +174,10 @@ mod tests {
     fn test_write_lockfile_sorted() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let index = make_index(&[("zzz", "1.0"), ("aaa", "2.0")]);
+        let resolved = make_resolved(&[("zzz", "1.0"), ("aaa", "2.0")]);
         let roots = vec!["zzz".to_string(), "aaa".to_string()];
-        let packages = vec!["zzz".to_string(), "aaa".to_string()];
 
-        write_lockfile_to(tmp.path(), &roots, &packages, &index);
+        write_lockfile_to(tmp.path(), &roots, &resolved, &index);
 
         let contents = std::fs::read_to_string(tmp.path()).unwrap();
         let aaa_pos = contents.find("\"aaa\"").unwrap();
@@ -170,26 +186,13 @@ mod tests {
     }
 
     #[test]
-    fn test_write_lockfile_skips_unknown_packages() {
-        let tmp = tempfile::NamedTempFile::new().unwrap();
-        let index = make_index(&[("ggplot2", "3.5.1")]);
-        let roots = vec!["ggplot2".to_string()];
-        let packages = vec!["ggplot2".to_string(), "unknown-pkg".to_string()];
-
-        write_lockfile_to(tmp.path(), &roots, &packages, &index);
-
-        let contents = std::fs::read_to_string(tmp.path()).unwrap();
-        assert!(!contents.contains("unknown-pkg"));
-    }
-
-    #[test]
     fn test_parse_lockfile_roundtrip() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let index = make_index(&[("ggplot2", "3.5.1"), ("rlang", "1.1.4")]);
+        let resolved = make_resolved(&[("ggplot2", "3.5.1"), ("rlang", "1.1.4")]);
         let roots = vec!["ggplot2".to_string()];
-        let packages = vec!["ggplot2".to_string(), "rlang".to_string()];
 
-        write_lockfile_to(tmp.path(), &roots, &packages, &index);
+        write_lockfile_to(tmp.path(), &roots, &resolved, &index);
 
         let text = std::fs::read_to_string(tmp.path()).unwrap();
         let mut parsed = parse_lockfile(&text);

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod index;
 mod installer;
 mod lockfile;
 mod resolver;
+mod version;
 
 use config::{parse_dep_name, read_config};
 use index::fetch_cran_index;

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,11 +66,19 @@ fn main() {
         Commands::Install { package } => {
             let t = Instant::now();
             let index = fetch_cran_index();
-            let deps = resolve(&package, &index);
-            let packages = build_urls(&deps, &index);
+            let resolved = resolve(&package, &index).unwrap_or_else(|e| {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            });
+            let dep_names: Vec<String> = resolved
+                .keys()
+                .filter(|n| *n != &package)
+                .cloned()
+                .collect();
+            let packages = build_urls(&dep_names, &index);
             println!(
                 "Resolved {} packages in {}",
-                deps.len(),
+                resolved.len(),
                 fmt_duration(t.elapsed().as_millis())
             );
 
@@ -103,14 +111,17 @@ fn main() {
 
             let t = Instant::now();
             let index = fetch_cran_index();
-            let all = resolve_all(&roots, &index);
+            let resolved = resolve_all(&roots, &index).unwrap_or_else(|e| {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            });
             println!(
                 "Resolved {} packages in {}",
-                all.len(),
+                resolved.len(),
                 fmt_duration(t.elapsed().as_millis())
             );
 
-            write_lockfile(&roots, &all, &index);
+            write_lockfile(&roots, &resolved, &index);
         }
 
         Commands::Sync => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod lockfile;
 mod resolver;
 mod version;
 
-use config::{parse_dep_name, read_config};
+use config::{parse_dep, parse_dep_name, read_config};
 use index::fetch_cran_index;
 use installer::{build_urls, build_urls_from_pairs, download_and_install};
 use lockfile::{lockfile_is_fresh, read_lockfile, write_lockfile};
@@ -102,16 +102,17 @@ fn main() {
 
         Commands::Lock => {
             let config = read_config();
-            let roots: Vec<String> = config
+            let root_deps: Vec<_> = config
                 .project
                 .dependencies
                 .iter()
-                .map(|d| parse_dep_name(d))
+                .map(|d| parse_dep(d))
                 .collect();
+            let root_names: Vec<String> = root_deps.iter().map(|d| d.name.clone()).collect();
 
             let t = Instant::now();
             let index = fetch_cran_index();
-            let resolved = resolve_all(&roots, &index).unwrap_or_else(|e| {
+            let resolved = resolve_all(&root_deps, &index).unwrap_or_else(|e| {
                 eprintln!("error: {e}");
                 std::process::exit(1);
             });
@@ -121,7 +122,7 @@ fn main() {
                 fmt_duration(t.elapsed().as_millis())
             );
 
-            write_lockfile(&roots, &resolved, &index);
+            write_lockfile(&root_names, &resolved, &index);
         }
 
         Commands::Sync => {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -200,4 +200,126 @@ mod tests {
         )];
         assert!(resolve("scales", &index).is_err());
     }
+
+    // --- version conflict and diamond dependency tests ---
+
+    fn constrained(name: &str, op: crate::version::Op, version: &str) -> Dep {
+        Dep::new(
+            name.to_string(),
+            Some(crate::version::VersionReq {
+                op,
+                version: RVersion::parse(version).unwrap(),
+            }),
+        )
+    }
+
+    /// Build an index where two packages (pkg_a, pkg_b) share a common dep,
+    /// each with their own constraint on it. Useful for diamond scenarios.
+    fn diamond_index(dep_a: Dep, dep_b: Dep, common_version: &str) -> HashMap<String, Package> {
+        let mut index = HashMap::new();
+        index.insert(
+            "root".to_string(),
+            Package {
+                version: "1.0".to_string(),
+                deps: vec![dep("pkg_a"), dep("pkg_b")],
+            },
+        );
+        index.insert(
+            "pkg_a".to_string(),
+            Package {
+                version: "1.0".to_string(),
+                deps: vec![dep_a],
+            },
+        );
+        index.insert(
+            "pkg_b".to_string(),
+            Package {
+                version: "1.0".to_string(),
+                deps: vec![dep_b],
+            },
+        );
+        index.insert(
+            "common".to_string(),
+            Package {
+                version: common_version.to_string(),
+                deps: vec![],
+            },
+        );
+        index
+    }
+
+    #[test]
+    fn test_diamond_compatible_constraints() {
+        use crate::version::Op;
+        // pkg_a needs common >= 1.0, pkg_b needs common >= 1.5
+        // available is 2.0 — satisfies both
+        let index = diamond_index(
+            constrained("common", Op::Gte, "1.0"),
+            constrained("common", Op::Gte, "1.5"),
+            "2.0",
+        );
+        let resolved = resolve("root", &index).unwrap();
+        assert!(resolved.contains_key("common"));
+        assert_eq!(resolved["common"], RVersion::parse("2.0").unwrap());
+    }
+
+    #[test]
+    fn test_diamond_conflicting_constraints() {
+        use crate::version::Op;
+        // pkg_a needs common >= 2.0, pkg_b needs common < 2.0
+        // available is 2.0 — fails the < 2.0 constraint
+        let index = diamond_index(
+            constrained("common", Op::Gte, "2.0"),
+            constrained("common", Op::Lt, "2.0"),
+            "2.0",
+        );
+        assert!(resolve("root", &index).is_err());
+    }
+
+    #[test]
+    fn test_transitive_conflict_propagates() {
+        use crate::version::Op;
+        // root -> pkg_a -> common >= 99.0, but common is at 1.0
+        let mut index = HashMap::new();
+        index.insert(
+            "root".to_string(),
+            Package {
+                version: "1.0".to_string(),
+                deps: vec![dep("pkg_a")],
+            },
+        );
+        index.insert(
+            "pkg_a".to_string(),
+            Package {
+                version: "1.0".to_string(),
+                deps: vec![constrained("common", Op::Gte, "99.0")],
+            },
+        );
+        index.insert(
+            "common".to_string(),
+            Package {
+                version: "1.0".to_string(),
+                deps: vec![],
+            },
+        );
+        assert!(resolve("root", &index).is_err());
+    }
+
+    #[test]
+    fn test_exact_version_match_passes() {
+        use crate::version::Op;
+        let mut index = make_index();
+        // require exactly rlang 1.1.4 — that's what's available
+        index.get_mut("scales").unwrap().deps = vec![constrained("rlang", Op::Eq, "1.1.4")];
+        assert!(resolve("scales", &index).is_ok());
+    }
+
+    #[test]
+    fn test_exact_version_match_fails() {
+        use crate::version::Op;
+        let mut index = make_index();
+        // require exactly rlang 1.1.3 — 1.1.4 is available, not 1.1.3
+        index.get_mut("scales").unwrap().deps = vec![constrained("rlang", Op::Eq, "1.1.3")];
+        assert!(resolve("scales", &index).is_err());
+    }
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -79,20 +79,28 @@ pub fn resolve(
         .map_err(|e| format!("dependency resolution failed for {root}: {e}"))
 }
 
-/// Resolves all transitive dependencies for multiple root packages.
-/// Returns a unified map of package name → resolved version.
+/// Resolves all transitive dependencies for multiple root packages, each with
+/// an optional version constraint from arrrv.toml. Uses a synthetic root package
+/// so that all constraints are fed into a single PubGrub resolution pass.
 pub fn resolve_all(
-    roots: &[String],
+    roots: &[crate::version::Dep],
     index: &HashMap<String, Package>,
 ) -> Result<HashMap<String, RVersion>, String> {
-    let mut all: HashMap<String, RVersion> = HashMap::new();
-    for root in roots {
-        let resolved = resolve(root, index)?;
-        for (name, version) in resolved {
-            all.insert(name, version);
-        }
-    }
-    Ok(all)
+    // Build a synthetic "__root__" package whose deps are the user's requirements.
+    // This lets PubGrub enforce all root constraints in one pass.
+    let synthetic_root = "__root__".to_string();
+    let mut augmented = index.clone();
+    augmented.insert(
+        synthetic_root.clone(),
+        Package {
+            version: "0".to_string(),
+            deps: roots.to_vec(),
+        },
+    );
+
+    let mut resolved = resolve(&synthetic_root, &augmented)?;
+    resolved.remove(&synthetic_root);
+    Ok(resolved)
 }
 
 #[cfg(test)]
@@ -163,11 +171,20 @@ mod tests {
     #[test]
     fn test_resolve_all_unions_results() {
         let index = make_index();
-        let roots = vec!["ggplot2".to_string(), "scales".to_string()];
+        let roots = vec![dep("ggplot2"), dep("scales")];
         let all = resolve_all(&roots, &index).unwrap();
         assert!(all.contains_key("ggplot2"));
         assert!(all.contains_key("scales"));
         assert!(all.contains_key("rlang"));
+    }
+
+    #[test]
+    fn test_resolve_all_enforces_root_constraints() {
+        use crate::version::Op;
+        let index = make_index();
+        // user pins rlang >= 99.0 in arrrv.toml — should fail at the root level
+        let roots = vec![constrained("rlang", Op::Gte, "99.0")];
+        assert!(resolve_all(&roots, &index).is_err());
     }
 
     #[test]

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -15,8 +15,8 @@ pub fn resolve(root: &str, index: &HashMap<String, Package>) -> Vec<String> {
 
         if let Some(pkg) = index.get(&name) {
             for dep in &pkg.deps {
-                if !visited.contains(dep) {
-                    queue.push_back(dep.clone());
+                if !visited.contains(&dep.name) {
+                    queue.push_back(dep.name.clone());
                 }
             }
         }
@@ -40,6 +40,11 @@ pub fn resolve_all(roots: &[String], index: &HashMap<String, Package>) -> Vec<St
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::version::Dep;
+
+    fn dep(name: &str) -> Dep {
+        Dep::new(name.to_string(), None)
+    }
 
     fn make_index() -> HashMap<String, Package> {
         let mut index = HashMap::new();
@@ -47,7 +52,7 @@ mod tests {
             "ggplot2".to_string(),
             Package {
                 version: "3.5.1".to_string(),
-                deps: vec!["rlang".to_string(), "scales".to_string()],
+                deps: vec![dep("rlang"), dep("scales")],
             },
         );
         index.insert(
@@ -61,7 +66,7 @@ mod tests {
             "scales".to_string(),
             Package {
                 version: "1.3.0".to_string(),
-                deps: vec!["rlang".to_string()],
+                deps: vec![dep("rlang")],
             },
         );
         index

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,40 +1,98 @@
 use crate::index::Package;
-use std::collections::{HashMap, HashSet, VecDeque};
+use crate::version::RVersion;
+use pubgrub::{Dependencies, DependencyConstraints, DependencyProvider, Ranges};
+use std::collections::HashMap;
+use std::convert::Infallible;
 
-pub fn resolve(root: &str, index: &HashMap<String, Package>) -> Vec<String> {
-    let mut visited: HashSet<String> = HashSet::new();
-    let mut queue: VecDeque<String> = VecDeque::new();
-
-    queue.push_back(root.to_string());
-
-    while let Some(name) = queue.pop_front() {
-        if visited.contains(&name) {
-            continue;
-        }
-        visited.insert(name.clone());
-
-        if let Some(pkg) = index.get(&name) {
-            for dep in &pkg.deps {
-                if !visited.contains(&dep.name) {
-                    queue.push_back(dep.name.clone());
-                }
-            }
-        }
-    }
-
-    visited.remove(root);
-    visited.into_iter().collect()
+/// Wraps the CRAN index so it can be used as a pubgrub DependencyProvider.
+struct CranProvider<'a> {
+    index: &'a HashMap<String, Package>,
 }
 
-pub fn resolve_all(roots: &[String], index: &HashMap<String, Package>) -> Vec<String> {
-    let mut all: HashSet<String> = HashSet::new();
+impl DependencyProvider for CranProvider<'_> {
+    type P = String;
+    type V = RVersion;
+    type VS = Ranges<RVersion>;
+    type M = String;
+    type Priority = usize;
+    type Err = Infallible;
+
+    fn prioritize(
+        &self,
+        _package: &String,
+        _range: &Ranges<RVersion>,
+        _stats: &pubgrub::PackageResolutionStatistics,
+    ) -> usize {
+        0
+    }
+
+    fn choose_version(
+        &self,
+        package: &String,
+        range: &Ranges<RVersion>,
+    ) -> Result<Option<RVersion>, Infallible> {
+        let Some(pkg) = self.index.get(package) else {
+            return Ok(None);
+        };
+        let v = RVersion::parse(&pkg.version).unwrap_or_else(RVersion::minimum);
+        Ok(range.contains(&v).then_some(v))
+    }
+
+    fn get_dependencies(
+        &self,
+        package: &String,
+        _version: &RVersion,
+    ) -> Result<Dependencies<String, Ranges<RVersion>, String>, Infallible> {
+        let Some(pkg) = self.index.get(package) else {
+            return Ok(Dependencies::Unavailable(format!(
+                "{package} not found in CRAN index"
+            )));
+        };
+        let mut deps: DependencyConstraints<String, Ranges<RVersion>> =
+            DependencyConstraints::default();
+        for dep in &pkg.deps {
+            let range = dep
+                .req
+                .as_ref()
+                .map(|r| r.to_range())
+                .unwrap_or_else(Ranges::full);
+            deps.insert(dep.name.clone(), range);
+        }
+        Ok(Dependencies::Available(deps))
+    }
+}
+
+/// Resolves all transitive dependencies of `root` and returns a map of
+/// package name → resolved version. Returns an error string if resolution fails.
+pub fn resolve(
+    root: &str,
+    index: &HashMap<String, Package>,
+) -> Result<HashMap<String, RVersion>, String> {
+    let provider = CranProvider { index };
+    let root_version = index
+        .get(root)
+        .and_then(|p| RVersion::parse(&p.version))
+        .unwrap_or_else(RVersion::minimum);
+
+    pubgrub::resolve(&provider, root.to_string(), root_version)
+        .map(|fx_map| fx_map.into_iter().collect::<HashMap<_, _>>())
+        .map_err(|e| format!("dependency resolution failed for {root}: {e}"))
+}
+
+/// Resolves all transitive dependencies for multiple root packages.
+/// Returns a unified map of package name → resolved version.
+pub fn resolve_all(
+    roots: &[String],
+    index: &HashMap<String, Package>,
+) -> Result<HashMap<String, RVersion>, String> {
+    let mut all: HashMap<String, RVersion> = HashMap::new();
     for root in roots {
-        all.insert(root.clone());
-        for dep in resolve(root, index) {
-            all.insert(dep);
+        let resolved = resolve(root, index)?;
+        for (name, version) in resolved {
+            all.insert(name, version);
         }
     }
-    all.into_iter().collect()
+    Ok(all)
 }
 
 #[cfg(test)]
@@ -75,41 +133,71 @@ mod tests {
     #[test]
     fn test_resolve_transitive_deps() {
         let index = make_index();
-        let mut deps = resolve("ggplot2", &index);
-        deps.sort();
-        assert_eq!(deps, vec!["rlang", "scales"]);
+        let resolved = resolve("ggplot2", &index).unwrap();
+        assert!(resolved.contains_key("rlang"));
+        assert!(resolved.contains_key("scales"));
     }
 
     #[test]
     fn test_resolve_deduplicates() {
         // rlang is a dep of both ggplot2 and scales — should only appear once
         let index = make_index();
-        let deps = resolve("ggplot2", &index);
-        let rlang_count = deps.iter().filter(|d| *d == "rlang").count();
-        assert_eq!(rlang_count, 1);
+        let resolved = resolve("ggplot2", &index).unwrap();
+        assert_eq!(resolved.keys().filter(|k| *k == "rlang").count(), 1);
     }
 
     #[test]
-    fn test_resolve_excludes_root() {
+    fn test_resolve_includes_root() {
+        // pubgrub returns the root package itself in the solution
         let index = make_index();
-        let deps = resolve("ggplot2", &index);
-        assert!(!deps.contains(&"ggplot2".to_string()));
+        let resolved = resolve("ggplot2", &index).unwrap();
+        assert!(resolved.contains_key("ggplot2"));
     }
 
     #[test]
-    fn test_resolve_unknown_package_returns_empty() {
+    fn test_resolve_unknown_package_returns_error() {
         let index = make_index();
-        let deps = resolve("nonexistent", &index);
-        assert!(deps.is_empty());
+        assert!(resolve("nonexistent", &index).is_err());
     }
 
     #[test]
     fn test_resolve_all_unions_results() {
         let index = make_index();
         let roots = vec!["ggplot2".to_string(), "scales".to_string()];
-        let all = resolve_all(&roots, &index);
-        assert!(all.contains(&"ggplot2".to_string()));
-        assert!(all.contains(&"scales".to_string()));
-        assert!(all.contains(&"rlang".to_string()));
+        let all = resolve_all(&roots, &index).unwrap();
+        assert!(all.contains_key("ggplot2"));
+        assert!(all.contains_key("scales"));
+        assert!(all.contains_key("rlang"));
+    }
+
+    #[test]
+    fn test_resolve_version_constraint_satisfied() {
+        use crate::version::{Op, VersionReq};
+        let mut index = make_index();
+        // scales requires rlang >= 1.0.0 — 1.1.4 satisfies this
+        index.get_mut("scales").unwrap().deps = vec![Dep::new(
+            "rlang".to_string(),
+            Some(VersionReq {
+                op: Op::Gte,
+                version: RVersion::parse("1.0.0").unwrap(),
+            }),
+        )];
+        let resolved = resolve("scales", &index).unwrap();
+        assert_eq!(resolved["rlang"], RVersion::parse("1.1.4").unwrap());
+    }
+
+    #[test]
+    fn test_resolve_version_constraint_unsatisfied() {
+        use crate::version::{Op, VersionReq};
+        let mut index = make_index();
+        // scales requires rlang >= 99.0 — 1.1.4 does NOT satisfy this
+        index.get_mut("scales").unwrap().deps = vec![Dep::new(
+            "rlang".to_string(),
+            Some(VersionReq {
+                op: Op::Gte,
+                version: RVersion::parse("99.0").unwrap(),
+            }),
+        )];
+        assert!(resolve("scales", &index).is_err());
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,180 @@
+use serde::{Deserialize, Serialize};
+
+/// An R package version: "1.1.0", "4.5", "2.23-26"
+/// Stored as a list of numeric parts for comparison.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RVersion {
+    parts: Vec<u32>,
+}
+
+impl PartialEq for RVersion {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for RVersion {}
+
+impl RVersion {
+    pub fn parse(s: &str) -> Option<Self> {
+        let parts: Option<Vec<u32>> = s.split(['.', '-']).map(|p| p.parse().ok()).collect();
+        parts.map(|p| RVersion { parts: p })
+    }
+}
+
+impl PartialOrd for RVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RVersion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let max_len = self.parts.len().max(other.parts.len());
+        for i in 0..max_len {
+            let a = self.parts.get(i).copied().unwrap_or(0);
+            let b = other.parts.get(i).copied().unwrap_or(0);
+            match a.cmp(&b) {
+                std::cmp::Ordering::Equal => continue,
+                ord => return ord,
+            }
+        }
+        std::cmp::Ordering::Equal
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Op {
+    Gte,
+    Gt,
+    Lte,
+    Lt,
+    Eq,
+}
+
+/// A version constraint: ">= 1.1.0"
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VersionReq {
+    pub op: Op,
+    pub version: RVersion,
+}
+
+impl VersionReq {
+    /// Parse from the interior of parentheses, e.g. ">= 1.1.0"
+    pub fn parse(s: &str) -> Option<Self> {
+        let s = s.trim();
+        let (op, rest) = if let Some(r) = s.strip_prefix(">=") {
+            (Op::Gte, r)
+        } else if let Some(r) = s.strip_prefix('>') {
+            (Op::Gt, r)
+        } else if let Some(r) = s.strip_prefix("<=") {
+            (Op::Lte, r)
+        } else if let Some(r) = s.strip_prefix('<') {
+            (Op::Lt, r)
+        } else if let Some(r) = s.strip_prefix("==") {
+            (Op::Eq, r)
+        } else if let Some(r) = s.strip_prefix('=') {
+            (Op::Eq, r)
+        } else {
+            return None;
+        };
+        let version = RVersion::parse(rest.trim())?;
+        Some(VersionReq { op, version })
+    }
+
+    #[allow(dead_code)] // will be used by the resolver
+    pub fn matches(&self, v: &RVersion) -> bool {
+        match self.op {
+            Op::Gte => v >= &self.version,
+            Op::Gt => v > &self.version,
+            Op::Lte => v <= &self.version,
+            Op::Lt => v < &self.version,
+            Op::Eq => v == &self.version,
+        }
+    }
+}
+
+/// A dependency: package name plus an optional version constraint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Dep {
+    pub name: String,
+    pub req: Option<VersionReq>,
+}
+
+impl Dep {
+    pub fn new(name: String, req: Option<VersionReq>) -> Self {
+        Dep { name, req }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rversion_parse_three_parts() {
+        let v = RVersion::parse("1.1.0").unwrap();
+        assert_eq!(v.parts, vec![1, 1, 0]);
+    }
+
+    #[test]
+    fn test_rversion_parse_two_parts() {
+        let v = RVersion::parse("4.5").unwrap();
+        assert_eq!(v.parts, vec![4, 5]);
+    }
+
+    #[test]
+    fn test_rversion_parse_dash() {
+        // base package style: "2.23-26"
+        let v = RVersion::parse("2.23-26").unwrap();
+        assert_eq!(v.parts, vec![2, 23, 26]);
+    }
+
+    #[test]
+    fn test_rversion_ordering() {
+        let v110 = RVersion::parse("1.1.0").unwrap();
+        let v114 = RVersion::parse("1.1.4").unwrap();
+        let v120 = RVersion::parse("1.2.0").unwrap();
+        assert!(v110 < v114);
+        assert!(v114 < v120);
+        assert!(v120 > v110);
+    }
+
+    #[test]
+    fn test_rversion_ordering_different_lengths() {
+        // "1.1" should equal "1.1.0" (missing parts default to 0)
+        let v11 = RVersion::parse("1.1").unwrap();
+        let v110 = RVersion::parse("1.1.0").unwrap();
+        assert_eq!(v11, v110);
+    }
+
+    #[test]
+    fn test_versionreq_parse_gte() {
+        let req = VersionReq::parse(">= 1.1.0").unwrap();
+        assert!(matches!(req.op, Op::Gte));
+        assert_eq!(req.version.parts, vec![1, 1, 0]);
+    }
+
+    #[test]
+    fn test_versionreq_matches() {
+        let req = VersionReq::parse(">= 1.1.0").unwrap();
+        assert!(req.matches(&RVersion::parse("1.1.0").unwrap()));
+        assert!(req.matches(&RVersion::parse("1.2.0").unwrap()));
+        assert!(!req.matches(&RVersion::parse("1.0.9").unwrap()));
+    }
+
+    #[test]
+    fn test_dep_parse_with_constraint() {
+        let req = VersionReq::parse(">= 1.1.0").unwrap();
+        let dep = Dep::new("rlang".to_string(), Some(req));
+        assert_eq!(dep.name, "rlang");
+        assert!(dep.req.is_some());
+    }
+
+    #[test]
+    fn test_dep_parse_no_constraint() {
+        let dep = Dep::new("scales".to_string(), None);
+        assert_eq!(dep.name, "scales");
+        assert!(dep.req.is_none());
+    }
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,3 +1,4 @@
+use pubgrub::Ranges;
 use serde::{Deserialize, Serialize};
 
 /// An R package version: "1.1.0", "4.5", "2.23-26"
@@ -19,6 +20,26 @@ impl RVersion {
     pub fn parse(s: &str) -> Option<Self> {
         let parts: Option<Vec<u32>> = s.split(['.', '-']).map(|p| p.parse().ok()).collect();
         parts.map(|p| RVersion { parts: p })
+    }
+
+    /// The smallest possible version — used as the lower bound by pubgrub.
+    pub fn minimum() -> Self {
+        RVersion { parts: vec![0] }
+    }
+
+    /// The next version after self — used by pubgrub to express exclusive upper bounds.
+    #[allow(dead_code)]
+    pub fn bump(&self) -> Self {
+        let mut parts = self.parts.clone();
+        *parts.last_mut().unwrap() += 1;
+        RVersion { parts }
+    }
+}
+
+impl std::fmt::Display for RVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s: Vec<String> = self.parts.iter().map(|p| p.to_string()).collect();
+        write!(f, "{}", s.join("."))
     }
 }
 
@@ -82,7 +103,7 @@ impl VersionReq {
         Some(VersionReq { op, version })
     }
 
-    #[allow(dead_code)] // will be used by the resolver
+    #[allow(dead_code)]
     pub fn matches(&self, v: &RVersion) -> bool {
         match self.op {
             Op::Gte => v >= &self.version,
@@ -90,6 +111,17 @@ impl VersionReq {
             Op::Lte => v <= &self.version,
             Op::Lt => v < &self.version,
             Op::Eq => v == &self.version,
+        }
+    }
+
+    /// Convert to a pubgrub `Ranges<RVersion>` for use in dependency resolution.
+    pub fn to_range(&self) -> Ranges<RVersion> {
+        match self.op {
+            Op::Gte => Ranges::higher_than(self.version.clone()),
+            Op::Gt => Ranges::strictly_higher_than(self.version.clone()),
+            Op::Lte => Ranges::lower_than(self.version.clone()),
+            Op::Lt => Ranges::strictly_lower_than(self.version.clone()),
+            Op::Eq => Ranges::singleton(self.version.clone()),
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #6, #7, #24

Replaces the BFS resolver (which ignored version constraints entirely) with a full PubGrub-based dependency resolution pass.

- **`src/version.rs`** (new) — `RVersion`, `Op`, `VersionReq`, `Dep` types; `RVersion` implements `Ord` with zero-padding so `"1.1" == "1.1.0"`; `VersionReq::to_range()` converts constraints to `pubgrub::Ranges`
- **`src/index.rs`** — `Package.deps` is now `Vec<Dep>`; `parse_packages` preserves constraints like `>= 1.1.0` instead of stripping them
- **`src/resolver.rs`** — `CranProvider` implements `DependencyProvider`; `resolve_all` injects a synthetic `__root__` package so all user constraints are enforced in a single PubGrub pass; version conflicts surface as clear errors
- **`src/config.rs`** — `parse_dep()` parses `"ggplot2>=3.4"` and `"rlang (>= 1.0)"` into full `Dep` structs with constraints
- **`src/lockfile.rs`** — writes original version string from index (preserves `"2.23-26"`, not `"2.23.26"`); adds `source = { registry = "..." }` per package entry for future multi-source support

## Test plan

- [x] 47 tests passing (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean
- [x] Diamond dependency with compatible constraints resolves correctly
- [x] Diamond dependency with conflicting constraints (`>= 2.0` vs `< 2.0`) errors
- [x] Transitive conflict propagates up the tree
- [x] Exact version match pass and fail
- [x] Dash version strings (`2.23-26`) preserved in lockfile
- [x] Root constraints from `arrrv.toml` enforced by PubGrub

🤖 Generated with [Claude Code](https://claude.com/claude-code)