### PR TITLE
feat: verbose resolution errors and fix missing base R package filter

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -55,15 +55,20 @@ pub fn parse_packages(text: &str) -> HashMap<String, Package> {
                             let base_packages = [
                                 "R",
                                 "base",
-                                "utils",
-                                "stats",
-                                "graphics",
-                                "grDevices",
-                                "methods",
-                                "datasets",
-                                "tools",
-                                "grid",
                                 "compiler",
+                                "datasets",
+                                "grDevices",
+                                "graphics",
+                                "grid",
+                                "methods",
+                                "parallel",
+                                "splines",
+                                "stats",
+                                "stats4",
+                                "tcltk",
+                                "tools",
+                                "translations",
+                                "utils",
                             ];
                             if !base_packages.contains(&dep_name.as_str()) && !dep_name.is_empty() {
                                 deps.push(Dep::new(dep_name, req));
@@ -170,6 +175,22 @@ mod tests {
         let pkg = index.get("foo").unwrap();
         assert!(!pkg.deps.iter().any(|d| d.name == "R"));
         assert!(!pkg.deps.iter().any(|d| d.name == "methods"));
+        assert!(pkg.deps.iter().any(|d| d.name == "rlang"));
+    }
+
+    #[test]
+    fn test_parse_filters_parallel_and_other_base() {
+        // parallel, splines, tcltk, stats4 ship with R and must not be treated
+        // as CRAN dependencies
+        let text = "Package: foo\nVersion: 1.0\nImports: parallel, splines, tcltk, stats4, rlang\n";
+        let index = parse_packages(text);
+        let pkg = index.get("foo").unwrap();
+        for base in &["parallel", "splines", "tcltk", "stats4"] {
+            assert!(
+                !pkg.deps.iter().any(|d| d.name == *base),
+                "{base} should be filtered out"
+            );
+        }
         assert!(pkg.deps.iter().any(|d| d.name == "rlang"));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
         Commands::Install { package } => {
             let t = Instant::now();
             let index = fetch_cran_index();
-            let resolved = resolve(&package, &index).unwrap_or_else(|e| {
+            let resolved = resolve(&package, &index, verbose).unwrap_or_else(|e| {
                 eprintln!("error: {e}");
                 std::process::exit(1);
             });
@@ -113,7 +113,7 @@ fn main() {
 
             let t = Instant::now();
             let index = fetch_cran_index();
-            let resolved = resolve_all(&root_deps, &index).unwrap_or_else(|e| {
+            let resolved = resolve_all(&root_deps, &index, verbose).unwrap_or_else(|e| {
                 eprintln!("error: {e}");
                 std::process::exit(1);
             });

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,6 +1,9 @@
 use crate::index::Package;
 use crate::version::RVersion;
-use pubgrub::{Dependencies, DependencyConstraints, DependencyProvider, Ranges};
+use pubgrub::{
+    DefaultStringReporter, Dependencies, DependencyConstraints, DependencyProvider, Ranges,
+    Reporter,
+};
 use std::collections::HashMap;
 use std::convert::Infallible;
 
@@ -64,9 +67,12 @@ impl DependencyProvider for CranProvider<'_> {
 
 /// Resolves all transitive dependencies of `root` and returns a map of
 /// package name → resolved version. Returns an error string if resolution fails.
+/// When `verbose` is true and there is no solution, the error includes the full
+/// PubGrub derivation tree explaining which constraints are incompatible.
 pub fn resolve(
     root: &str,
     index: &HashMap<String, Package>,
+    verbose: bool,
 ) -> Result<HashMap<String, RVersion>, String> {
     let provider = CranProvider { index };
     let root_version = index
@@ -76,7 +82,13 @@ pub fn resolve(
 
     pubgrub::resolve(&provider, root.to_string(), root_version)
         .map(|fx_map| fx_map.into_iter().collect::<HashMap<_, _>>())
-        .map_err(|e| format!("dependency resolution failed for {root}: {e}"))
+        .map_err(|e| {
+            if verbose && let pubgrub::PubGrubError::NoSolution(tree) = &e {
+                let report = DefaultStringReporter::report(tree);
+                return format!("dependency resolution failed for {root}:\n{report}");
+            }
+            format!("dependency resolution failed for {root}: {e}")
+        })
 }
 
 /// Resolves all transitive dependencies for multiple root packages, each with
@@ -85,6 +97,7 @@ pub fn resolve(
 pub fn resolve_all(
     roots: &[crate::version::Dep],
     index: &HashMap<String, Package>,
+    verbose: bool,
 ) -> Result<HashMap<String, RVersion>, String> {
     // Build a synthetic "__root__" package whose deps are the user's requirements.
     // This lets PubGrub enforce all root constraints in one pass.
@@ -98,7 +111,7 @@ pub fn resolve_all(
         },
     );
 
-    let mut resolved = resolve(&synthetic_root, &augmented)?;
+    let mut resolved = resolve(&synthetic_root, &augmented, verbose)?;
     resolved.remove(&synthetic_root);
     Ok(resolved)
 }
@@ -141,7 +154,7 @@ mod tests {
     #[test]
     fn test_resolve_transitive_deps() {
         let index = make_index();
-        let resolved = resolve("ggplot2", &index).unwrap();
+        let resolved = resolve("ggplot2", &index, false).unwrap();
         assert!(resolved.contains_key("rlang"));
         assert!(resolved.contains_key("scales"));
     }
@@ -150,7 +163,7 @@ mod tests {
     fn test_resolve_deduplicates() {
         // rlang is a dep of both ggplot2 and scales — should only appear once
         let index = make_index();
-        let resolved = resolve("ggplot2", &index).unwrap();
+        let resolved = resolve("ggplot2", &index, false).unwrap();
         assert_eq!(resolved.keys().filter(|k| *k == "rlang").count(), 1);
     }
 
@@ -158,21 +171,21 @@ mod tests {
     fn test_resolve_includes_root() {
         // pubgrub returns the root package itself in the solution
         let index = make_index();
-        let resolved = resolve("ggplot2", &index).unwrap();
+        let resolved = resolve("ggplot2", &index, false).unwrap();
         assert!(resolved.contains_key("ggplot2"));
     }
 
     #[test]
     fn test_resolve_unknown_package_returns_error() {
         let index = make_index();
-        assert!(resolve("nonexistent", &index).is_err());
+        assert!(resolve("nonexistent", &index, false).is_err());
     }
 
     #[test]
     fn test_resolve_all_unions_results() {
         let index = make_index();
         let roots = vec![dep("ggplot2"), dep("scales")];
-        let all = resolve_all(&roots, &index).unwrap();
+        let all = resolve_all(&roots, &index, false).unwrap();
         assert!(all.contains_key("ggplot2"));
         assert!(all.contains_key("scales"));
         assert!(all.contains_key("rlang"));
@@ -184,7 +197,7 @@ mod tests {
         let index = make_index();
         // user pins rlang >= 99.0 in arrrv.toml — should fail at the root level
         let roots = vec![constrained("rlang", Op::Gte, "99.0")];
-        assert!(resolve_all(&roots, &index).is_err());
+        assert!(resolve_all(&roots, &index, false).is_err());
     }
 
     #[test]
@@ -199,7 +212,7 @@ mod tests {
                 version: RVersion::parse("1.0.0").unwrap(),
             }),
         )];
-        let resolved = resolve("scales", &index).unwrap();
+        let resolved = resolve("scales", &index, false).unwrap();
         assert_eq!(resolved["rlang"], RVersion::parse("1.1.4").unwrap());
     }
 
@@ -215,7 +228,7 @@ mod tests {
                 version: RVersion::parse("99.0").unwrap(),
             }),
         )];
-        assert!(resolve("scales", &index).is_err());
+        assert!(resolve("scales", &index, false).is_err());
     }
 
     // --- version conflict and diamond dependency tests ---
@@ -275,7 +288,7 @@ mod tests {
             constrained("common", Op::Gte, "1.5"),
             "2.0",
         );
-        let resolved = resolve("root", &index).unwrap();
+        let resolved = resolve("root", &index, false).unwrap();
         assert!(resolved.contains_key("common"));
         assert_eq!(resolved["common"], RVersion::parse("2.0").unwrap());
     }
@@ -290,7 +303,7 @@ mod tests {
             constrained("common", Op::Lt, "2.0"),
             "2.0",
         );
-        assert!(resolve("root", &index).is_err());
+        assert!(resolve("root", &index, false).is_err());
     }
 
     #[test]
@@ -319,7 +332,7 @@ mod tests {
                 deps: vec![],
             },
         );
-        assert!(resolve("root", &index).is_err());
+        assert!(resolve("root", &index, false).is_err());
     }
 
     #[test]
@@ -328,7 +341,7 @@ mod tests {
         let mut index = make_index();
         // require exactly rlang 1.1.4 — that's what's available
         index.get_mut("scales").unwrap().deps = vec![constrained("rlang", Op::Eq, "1.1.4")];
-        assert!(resolve("scales", &index).is_ok());
+        assert!(resolve("scales", &index, false).is_ok());
     }
 
     #[test]
@@ -337,6 +350,6 @@ mod tests {
         let mut index = make_index();
         // require exactly rlang 1.1.3 — 1.1.4 is available, not 1.1.3
         index.get_mut("scales").unwrap().deps = vec![constrained("rlang", Op::Eq, "1.1.3")];
-        assert!(resolve("scales", &index).is_err());
+        assert!(resolve("scales", &index, false).is_err());
     }
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -65,6 +65,25 @@ impl DependencyProvider for CranProvider<'_> {
     }
 }
 
+/// Formats the raw PubGrub no-solution report into a numbered, indented chain.
+/// Each "Because …" clause gets its own step, and each step is indented two
+/// more spaces than the previous one to make the dependency chain visually clear.
+/// The internal synthetic package name is replaced with "your project".
+fn format_no_solution(report: &str) -> String {
+    let mut out = String::new();
+    let mut step = 0usize;
+    for line in report.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let line = line.replace("__root__ 0", "your project");
+        let indent = "  ".repeat(step);
+        out.push_str(&format!("{}{}. {}\n", indent, step + 1, line));
+        step += 1;
+    }
+    out.trim_end().to_string()
+}
+
 /// Resolves all transitive dependencies of `root` and returns a map of
 /// package name → resolved version. Returns an error string if resolution fails.
 /// When `verbose` is true and there is no solution, the error includes the full
@@ -85,9 +104,12 @@ pub fn resolve(
         .map_err(|e| {
             if verbose && let pubgrub::PubGrubError::NoSolution(tree) = &e {
                 let report = DefaultStringReporter::report(tree);
-                return format!("dependency resolution failed for {root}:\n{report}");
+                return format!(
+                    "dependency resolution failed:\n{}",
+                    format_no_solution(&report)
+                );
             }
-            format!("dependency resolution failed for {root}: {e}")
+            format!("dependency resolution failed: {e}")
         })
 }
 


### PR DESCRIPTION
## Summary

- Adds `--verbose` flag support to `arrrv lock` and `arrrv install`: when dependency resolution fails, a numbered, indented conflict chain is printed showing exactly which constraints are incompatible (using PubGrub's derivation tree)
- Fixes #34: `parallel`, `splines`, `stats4`, `tcltk`, and `translations` were missing from the base R package filter, causing the resolver to look them up on CRAN and fail with a spurious "no available version" error

## Test plan

- [x] `cargo test` passes (51 tests)
- [x] `arrrv --verbose lock` on a project with a conflict shows a numbered, indented chain
- [x] `arrrv lock` on a project depending on `tidymodels` (or any package that uses `parallel`) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)