### PR TITLE
chore: bump version to 0.1.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "arrrv"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arrrv"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Bumps `Cargo.toml` version to `0.1.0-alpha.1` ahead of the first pre-release tag.

Once merged, the tag `v0.1.0-alpha.1` will be pushed manually to trigger the release workflow.