### PR TITLE
feature/linux compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,15 @@ jobs:
             runs-on: macos-latest
           - target: x86_64-apple-darwin
             runs-on: macos-15-intel
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install musl tools (Linux only)
+        if: contains(matrix.target, 'musl')
+        run: sudo apt-get install -y musl-tools
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,21 @@ jobs:
             runs-on: macos-15-intel
           - target: x86_64-unknown-linux-musl
             runs-on: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install musl tools (Linux only)
-        if: contains(matrix.target, 'musl')
+      - name: Install musl tools (Linux x86_64)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get install -y musl-tools
+
+      - name: Install musl tools (Linux aarch64)
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        run: |
+          sudo apt-get install -y gcc-aarch64-linux-gnu musl-tools
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1243,7 +1243,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ruv"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,14 +126,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -154,10 +190,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "console"
@@ -255,6 +310,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,21 +377,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +384,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -395,8 +447,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -406,9 +460,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -484,18 +540,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
+name = "hyper-rustls"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "bytes",
- "http-body-util",
+ "http",
  "hyper",
  "hyper-util",
- "native-tls",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -676,6 +732,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +810,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,23 +843,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,48 +855,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -846,12 +885,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +903,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -902,8 +944,64 @@ dependencies = [
  "log",
  "priority-queue",
  "rustc-hash",
- "thiserror",
+ "thiserror 2.0.18",
  "version-ranges",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -920,6 +1018,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rayon"
@@ -958,7 +1085,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -976,19 +1103,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -996,6 +1125,20 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1018,12 +1161,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1049,6 +1258,15 @@ dependencies = [
  "tar",
  "tempfile",
  "toml",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1182,6 +1400,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,11 +1462,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1267,6 +1511,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,12 +1540,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-rustls"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "native-tls",
+ "rustls",
  "tokio",
 ]
 
@@ -1418,6 +1677,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,18 +1707,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version-ranges"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3595ffe225639f1e0fd8d7269dcc05d2fbfea93cfac2fea367daf1adb60aae91"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1560,6 +1829,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,11 +1854,29 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1585,20 +1890,63 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1608,9 +1956,33 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1620,9 +1992,27 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1632,15 +2022,51 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1697,6 +2123,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ flate2 = "1.1.9"
 indicatif = "0.18.4"
 pubgrub = "0.3.0"
 rayon = "1.11.0"
-reqwest = { version = "0.13.2", features = ["blocking", "native-tls", "json"], default-features = false }
+reqwest = { version = "0.13.2", features = ["blocking", "rustls", "json"], default-features = false }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tar = "0.4.44"
@@ -26,7 +26,7 @@ tempfile = "3.26.0"
 targets = [
     "aarch64-apple-darwin",   # macOS ARM (M1/M2/M3/etc)
     "x86_64-apple-darwin",    # macOS Intel
-    "x86_64-unknown-linux-gnu" # Linux x86_64
+    "x86_64-unknown-linux-musl" # Linux x86_64 (static, no glibc dependency)
 ]
 # Installer to generate (shell script for curl | sh)
 installers = ["shell"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ tempfile = "3.26.0"
 targets = [
     "aarch64-apple-darwin",   # macOS ARM (M1/M2/M3/etc)
     "x86_64-apple-darwin",    # macOS Intel
-    "x86_64-unknown-linux-musl" # Linux x86_64 (static, no glibc dependency)
+    "x86_64-unknown-linux-musl",  # Linux x86_64 (static, no glibc dependency)
+    "aarch64-unknown-linux-musl"  # Linux ARM64 (Graviton, Raspberry Pi, etc)
 ]
 # Installer to generate (shell script for curl | sh)
 installers = ["shell"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruv"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2024"
 
 [dependencies]

--- a/project_docs/linux_build.md
+++ b/project_docs/linux_build.md
@@ -90,7 +90,7 @@ CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
 ```bash
 # Force x86_64 on M-series Mac
 docker run --rm --platform linux/amd64 ubuntu:22.04 bash -c "
-  apt-get update -q && apt-get install -y dash curl
+  DEBIAN_FRONTEND=noninteractive apt-get update -q && apt-get install -y dash curl
   curl -fsSL https://github.com/A-Fisk/ruv/releases/latest/download/install.sh | dash -s
 "
 ```
@@ -129,7 +129,7 @@ docker run --rm \
 docker run --rm --platform linux/amd64 \
   -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
   ubuntu:22.04 bash -c "
-    apt-get update -q && apt-get install -y r-base
+    DEBIAN_FRONTEND=noninteractive apt-get update -q && DEBIAN_FRONTEND=noninteractive apt-get install -y r-base
     mkdir /test && cd /test
     cat > ruv.toml << 'EOF'
 [project]
@@ -151,7 +151,7 @@ EOF
 docker run --rm --platform linux/amd64 \
   -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
   ubuntu:22.04 bash -c "
-    apt-get update -q && apt-get install -y r-base
+    DEBIAN_FRONTEND=noninteractive apt-get update -q && DEBIAN_FRONTEND=noninteractive apt-get install -y r-base
     mkdir /test && cd /test
     cat > ruv.toml << 'EOF'
 [project]
@@ -173,7 +173,7 @@ EOF
 ```bash
 cat > /tmp/ruv-test.Dockerfile << 'EOF'
 FROM ubuntu:22.04
-RUN apt-get update && apt-get install -y r-base && rm -rf /var/lib/apt/lists/*
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y r-base && rm -rf /var/lib/apt/lists/*
 COPY target/x86_64-unknown-linux-musl/release/ruv /usr/local/bin/ruv
 WORKDIR /project
 RUN cat > ruv.toml << 'TOML'

--- a/project_docs/linux_build.md
+++ b/project_docs/linux_build.md
@@ -4,40 +4,36 @@ See GitHub issue #50 for the umbrella tracking issue.
 
 ## Implementation phases
 
-### Phase 1 — `install.sh` POSIX fix (5 min, zero risk)
+### Phase 1 — `install.sh` POSIX fix
 - Change shebang `#!/bin/bash` → `#!/bin/sh`
-- Replace line 89 `[[ ":$PATH:" == *":$INSTALL_DIR:"* ]]` with a `case` statement (POSIX-compatible)
-- Update the Linux `TARGET` string from `x86_64-unknown-linux-gnu` → `x86_64-unknown-linux-musl` (coupled to Phase 2)
+- Replace `[[ ":$PATH:" == *":$INSTALL_DIR:"* ]]` with a `case` statement (POSIX-compatible)
+- Update Linux `TARGET` strings: `x86_64-unknown-linux-gnu` → `x86_64-unknown-linux-musl`, add `aarch64-unknown-linux-musl`
 
-### Phase 2 — Musl static build in CI (the core fix)
-This is the real glibc fix. The binary currently links against `GLIBC_2.39` (Ubuntu 24.04 runner)
-but Ubuntu 22.04 only has `GLIBC_2.35`. A musl build is statically linked — runs on any Linux kernel ≥ 3.2.
+### Phase 2 — Musl static builds in CI
+Musl builds are statically linked — no glibc dependency, runs on any Linux kernel ≥ 3.2.
 
-- **`Cargo.toml`**: Switch `reqwest` from `native-tls` → `rustls-tls` (required — musl can't link OpenSSL at build time)
-- **`release.yml`**: Replace `x86_64-unknown-linux-gnu` with `x86_64-unknown-linux-musl`, add `musl-tools` install step
-- **`Cargo.toml` dist targets**: Update the targets list to match
+- **`Cargo.toml`**: Switch `reqwest` from `native-tls` → `rustls` (required — musl can't link OpenSSL)
+- **`release.yml`**: Replace `x86_64-unknown-linux-gnu` with `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`; add `musl-tools` / `gcc-aarch64-linux-gnu` install steps
+- **`Cargo.toml` dist targets**: Update to match
 
 ### Phase 3 — Package installs work on Linux
-`get_arch()` in `installer.rs` currently panics on Linux. RSPM URL structure is different:
+`get_arch()` in `installer.rs` panicked on Linux. RSPM URL structure differs:
 - macOS: `bin/macosx/big-sur-arm64/contrib/4.4/pkg.tgz`
 - Linux: `bin/linux/ubuntu-jammy/contrib/4.4/pkg.tar.gz`
 
-Refactor `get_arch()` → `get_platform_path()` that reads `/etc/os-release` on Linux and maps to
-RSPM distro names (`ubuntu-jammy`, `ubuntu-noble`, etc). Also handle the `.tgz` vs `.tar.gz`
-extension difference.
+Refactored to `get_platform()` which reads `/etc/os-release` and maps to RSPM distro names
+(`ubuntu-jammy`, `ubuntu-noble`, etc). Handles `.tgz` vs `.tar.gz` extension difference.
 
 ### Phase 4 — Linux R discovery paths
-`find_r_installations()` searches `/opt/homebrew/bin` (macOS only — move behind
-`#[cfg(target_os = "macos")]`) and misses Linux-specific paths:
-- `/opt/R/*/bin/` — where Posit/rig installs R versions
-- `/usr/bin/R` — already covered
+- Moved `/opt/homebrew/bin` behind `#[cfg(target_os = "macos")]`
+- Added `/opt/R/*/bin/` for Posit/rig managed installations on Linux
 
 ### Phase 5 — Linux R auto-download (follow-on issue)
-The current stub just errors with "only supported on macOS". The right approach is **Posit
-pre-built `.deb` binaries** from `cdn.posit.co/r/{distro}/pkgs/r-{version}_1_amd64.deb` — same
-binaries rig uses, no sudo required (extract the `.deb` as an `ar` archive → unpack `data.tar.xz`).
+The current stub errors with "only supported on macOS". The right approach is Posit pre-built
+`.deb` binaries from `cdn.posit.co/r/{distro}/pkgs/r-{version}_1_amd64.deb` — same binaries
+rig uses, no sudo required (extract the `.deb` as an `ar` archive → unpack `data.tar.xz`).
 
-This is more work so should be its own issue after #50 is closed.
+This is a separate follow-on issue after #50 is closed.
 
 ### Dependency order
 
@@ -53,52 +49,85 @@ Phase 5 (auto-download R on Linux) ← separate follow-on issue
 ```
 
 Phases 1–4 together close #50 and make ruv fully functional on Linux (install, sync, run).
-Phase 5 is a separate issue for R version management on Linux.
 
 ---
 
 ## Manual verification via Docker
 
-### Setup — build the musl binary locally first
-```bash
-# Install the musl target (one-time)
-rustup target add x86_64-unknown-linux-musl
+### Prerequisites
 
-# On macOS you need a musl cross-compiler
+**On macOS with an M-series chip**, Docker containers run as `aarch64` by default.
+Use `--platform linux/amd64` to test x86_64 behaviour, or omit it to test aarch64.
+
+**Docker daemon**: requires Docker Desktop or Colima (`brew install colima && colima start`).
+The plain `brew install docker` only installs the CLI — you need the daemon too.
+
+---
+
+### Setup — build the musl binaries locally
+
+```bash
+# Install targets (one-time)
+rustup target add x86_64-unknown-linux-musl
+rustup target add aarch64-unknown-linux-musl
+
+# On macOS you need musl cross-compilers
 brew install FiloSottile/musl-cross/musl-cross
 
-# Build
+# Build x86_64
 CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc \
   cargo build --release --target x86_64-unknown-linux-musl
+
+# Build aarch64
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
+  cargo build --release --target aarch64-unknown-linux-musl
 ```
 
+---
+
 ### Phase 1 — verify `install.sh` works under POSIX sh
+
 ```bash
-# Run the install script under dash (Ubuntu's /bin/sh) — catches any bash-isms
-docker run --rm ubuntu:22.04 bash -c "
-  apt-get install -y dash curl > /dev/null 2>&1
+# Force x86_64 on M-series Mac
+docker run --rm --platform linux/amd64 ubuntu:22.04 bash -c "
+  apt-get update -q && apt-get install -y dash curl
   curl -fsSL https://github.com/A-Fisk/ruv/releases/latest/download/install.sh | dash -s
 "
 ```
 
+---
+
 ### Phase 2 — verify musl binary runs on old glibc
+
 ```bash
-# Ubuntu 22.04 has GLIBC_2.35 — this is the main compatibility target
-docker run --rm -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
+# Ubuntu 22.04 (GLIBC_2.35) — main compatibility target
+docker run --rm --platform linux/amd64 \
+  -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
   ubuntu:22.04 ruv --help
 
-# Also test on older Ubuntu 20.04 (GLIBC_2.31)
-docker run --rm -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
+# Ubuntu 20.04 (GLIBC_2.31)
+docker run --rm --platform linux/amd64 \
+  -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
   ubuntu:20.04 ruv --help
 
-# And Alpine (musl natively — good smoke test)
-docker run --rm -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
+# Alpine (musl natively — good smoke test)
+docker run --rm --platform linux/amd64 \
+  -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
   alpine:latest ruv --help
+
+# aarch64 (native on M-series Mac, no --platform needed)
+docker run --rm \
+  -v $(pwd)/target/aarch64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
+  ubuntu:22.04 ruv --help
 ```
 
+---
+
 ### Phase 3 — verify package install works on Linux
+
 ```bash
-docker run --rm -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
+docker run --rm --platform linux/amd64 \
+  -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
   ubuntu:22.04 bash -c "
     apt-get update -q && apt-get install -y r-base
     mkdir /test && cd /test
@@ -114,9 +143,13 @@ EOF
   "
 ```
 
+---
+
 ### Phase 4 — verify R discovery finds system R
+
 ```bash
-docker run --rm -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
+docker run --rm --platform linux/amd64 \
+  -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
   ubuntu:22.04 bash -c "
     apt-get update -q && apt-get install -y r-base
     mkdir /test && cd /test
@@ -133,9 +166,11 @@ EOF
 # Should NOT print: R not found locally, downloading...
 ```
 
+---
+
 ### End-to-end sanity check (all phases)
+
 ```bash
-# Minimal Dockerfile for a clean reproducible test
 cat > /tmp/ruv-test.Dockerfile << 'EOF'
 FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y r-base && rm -rf /var/lib/apt/lists/*
@@ -152,7 +187,7 @@ RUN ruv lock && ruv sync
 RUN ruv run -e 'library(jsonlite); library(dplyr); cat("all packages OK\n")'
 EOF
 
-docker build -f /tmp/ruv-test.Dockerfile .
+docker build --platform linux/amd64 -f /tmp/ruv-test.Dockerfile .
 ```
 
 A clean `docker build` with no errors = all phases verified.

--- a/project_docs/linux_build.md
+++ b/project_docs/linux_build.md
@@ -1,0 +1,158 @@
+# Linux compatibility — build and verification
+
+See GitHub issue #50 for the umbrella tracking issue.
+
+## Implementation phases
+
+### Phase 1 — `install.sh` POSIX fix (5 min, zero risk)
+- Change shebang `#!/bin/bash` → `#!/bin/sh`
+- Replace line 89 `[[ ":$PATH:" == *":$INSTALL_DIR:"* ]]` with a `case` statement (POSIX-compatible)
+- Update the Linux `TARGET` string from `x86_64-unknown-linux-gnu` → `x86_64-unknown-linux-musl` (coupled to Phase 2)
+
+### Phase 2 — Musl static build in CI (the core fix)
+This is the real glibc fix. The binary currently links against `GLIBC_2.39` (Ubuntu 24.04 runner)
+but Ubuntu 22.04 only has `GLIBC_2.35`. A musl build is statically linked — runs on any Linux kernel ≥ 3.2.
+
+- **`Cargo.toml`**: Switch `reqwest` from `native-tls` → `rustls-tls` (required — musl can't link OpenSSL at build time)
+- **`release.yml`**: Replace `x86_64-unknown-linux-gnu` with `x86_64-unknown-linux-musl`, add `musl-tools` install step
+- **`Cargo.toml` dist targets**: Update the targets list to match
+
+### Phase 3 — Package installs work on Linux
+`get_arch()` in `installer.rs` currently panics on Linux. RSPM URL structure is different:
+- macOS: `bin/macosx/big-sur-arm64/contrib/4.4/pkg.tgz`
+- Linux: `bin/linux/ubuntu-jammy/contrib/4.4/pkg.tar.gz`
+
+Refactor `get_arch()` → `get_platform_path()` that reads `/etc/os-release` on Linux and maps to
+RSPM distro names (`ubuntu-jammy`, `ubuntu-noble`, etc). Also handle the `.tgz` vs `.tar.gz`
+extension difference.
+
+### Phase 4 — Linux R discovery paths
+`find_r_installations()` searches `/opt/homebrew/bin` (macOS only — move behind
+`#[cfg(target_os = "macos")]`) and misses Linux-specific paths:
+- `/opt/R/*/bin/` — where Posit/rig installs R versions
+- `/usr/bin/R` — already covered
+
+### Phase 5 — Linux R auto-download (follow-on issue)
+The current stub just errors with "only supported on macOS". The right approach is **Posit
+pre-built `.deb` binaries** from `cdn.posit.co/r/{distro}/pkgs/r-{version}_1_amd64.deb` — same
+binaries rig uses, no sudo required (extract the `.deb` as an `ar` archive → unpack `data.tar.xz`).
+
+This is more work so should be its own issue after #50 is closed.
+
+### Dependency order
+
+```
+Phase 1 (install.sh)
+    ↓
+Phase 2 (musl build) ← reqwest→rustls is a hard dependency
+    ↓
+Phase 3 (RSPM Linux URLs) ← needed for ruv sync to work on Linux
+Phase 4 (R discovery paths) ← independent, low risk
+    ↓
+Phase 5 (auto-download R on Linux) ← separate follow-on issue
+```
+
+Phases 1–4 together close #50 and make ruv fully functional on Linux (install, sync, run).
+Phase 5 is a separate issue for R version management on Linux.
+
+---
+
+## Manual verification via Docker
+
+### Setup — build the musl binary locally first
+```bash
+# Install the musl target (one-time)
+rustup target add x86_64-unknown-linux-musl
+
+# On macOS you need a musl cross-compiler
+brew install FiloSottile/musl-cross/musl-cross
+
+# Build
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc \
+  cargo build --release --target x86_64-unknown-linux-musl
+```
+
+### Phase 1 — verify `install.sh` works under POSIX sh
+```bash
+# Run the install script under dash (Ubuntu's /bin/sh) — catches any bash-isms
+docker run --rm ubuntu:22.04 bash -c "
+  apt-get install -y dash curl > /dev/null 2>&1
+  curl -fsSL https://github.com/A-Fisk/ruv/releases/latest/download/install.sh | dash -s
+"
+```
+
+### Phase 2 — verify musl binary runs on old glibc
+```bash
+# Ubuntu 22.04 has GLIBC_2.35 — this is the main compatibility target
+docker run --rm -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
+  ubuntu:22.04 ruv --help
+
+# Also test on older Ubuntu 20.04 (GLIBC_2.31)
+docker run --rm -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
+  ubuntu:20.04 ruv --help
+
+# And Alpine (musl natively — good smoke test)
+docker run --rm -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
+  alpine:latest ruv --help
+```
+
+### Phase 3 — verify package install works on Linux
+```bash
+docker run --rm -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
+  ubuntu:22.04 bash -c "
+    apt-get update -q && apt-get install -y r-base
+    mkdir /test && cd /test
+    cat > ruv.toml << 'EOF'
+[project]
+name = \"test\"
+version = \"0.1.0\"
+dependencies = [\"jsonlite\"]
+EOF
+    ruv lock
+    ruv sync
+    ruv run -e 'library(jsonlite); cat(\"OK\n\")'
+  "
+```
+
+### Phase 4 — verify R discovery finds system R
+```bash
+docker run --rm -v $(pwd)/target/x86_64-unknown-linux-musl/release/ruv:/usr/local/bin/ruv \
+  ubuntu:22.04 bash -c "
+    apt-get update -q && apt-get install -y r-base
+    mkdir /test && cd /test
+    cat > ruv.toml << 'EOF'
+[project]
+name = \"test\"
+version = \"0.1.0\"
+r-version = \"4\"
+dependencies = []
+EOF
+    ruv lock && ruv sync
+  "
+# Should print: Using R 4.x.x (/usr/bin)
+# Should NOT print: R not found locally, downloading...
+```
+
+### End-to-end sanity check (all phases)
+```bash
+# Minimal Dockerfile for a clean reproducible test
+cat > /tmp/ruv-test.Dockerfile << 'EOF'
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y r-base && rm -rf /var/lib/apt/lists/*
+COPY target/x86_64-unknown-linux-musl/release/ruv /usr/local/bin/ruv
+WORKDIR /project
+RUN cat > ruv.toml << 'TOML'
+[project]
+name = "test"
+version = "0.1.0"
+r-version = "4"
+dependencies = ["jsonlite", "dplyr"]
+TOML
+RUN ruv lock && ruv sync
+RUN ruv run -e 'library(jsonlite); library(dplyr); cat("all packages OK\n")'
+EOF
+
+docker build -f /tmp/ruv-test.Dockerfile .
+```
+
+A clean `docker build` with no errors = all phases verified.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -36,8 +36,11 @@ case "$(uname -s)" in
       x86_64)
         TARGET="x86_64-unknown-linux-musl"
         ;;
+      aarch64)
+        TARGET="aarch64-unknown-linux-musl"
+        ;;
       *)
-        echo "Error: Linux only supports x86_64. Found: $(uname -m)"
+        echo "Error: Unsupported Linux architecture: $(uname -m)"
         exit 1
         ;;
     esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 REPO="A-Fisk/ruv"
@@ -34,7 +34,7 @@ case "$(uname -s)" in
   Linux)
     case "$(uname -m)" in
       x86_64)
-        TARGET="x86_64-unknown-linux-gnu"
+        TARGET="x86_64-unknown-linux-musl"
         ;;
       *)
         echo "Error: Linux only supports x86_64. Found: $(uname -m)"
@@ -79,23 +79,26 @@ cp "$BINARY_PATH" "$INSTALL_DIR/ruv"
 chmod +x "$INSTALL_DIR/ruv"
 
 echo ""
-echo "✓ ruv $TAG installed successfully!"
+echo "ruv $TAG installed successfully!"
 echo ""
 
 echo "Binary location: $INSTALL_DIR/ruv"
 echo ""
 
-# Check if install dir is in PATH
-if [[ ":$PATH:" == *":$INSTALL_DIR:"* ]]; then
-  echo "✓ $INSTALL_DIR is already in your \$PATH"
-  echo ""
-  echo "You can now run: ruv --help"
-else
-  echo "⚠ $INSTALL_DIR is NOT in your \$PATH"
-  echo ""
-  echo "Add this line to your shell profile (~/.zshrc, ~/.bashrc, etc):"
-  echo ""
-  echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
-  echo ""
-  echo "Then restart your terminal or run: source ~/.zshrc"
-fi
+# Check if install dir is in PATH (POSIX-compatible)
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*)
+    echo "$INSTALL_DIR is already in your \$PATH"
+    echo ""
+    echo "You can now run: ruv --help"
+    ;;
+  *)
+    echo "WARNING: $INSTALL_DIR is NOT in your \$PATH"
+    echo ""
+    echo "Add this line to your shell profile (~/.zshrc, ~/.bashrc, etc):"
+    echo ""
+    echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+    echo ""
+    echo "Then restart your terminal or run: source ~/.zshrc"
+    ;;
+esac

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -345,8 +345,8 @@ mod tests {
         let (name, version, url) = &urls[0];
         assert_eq!(name, "ggplot2");
         assert_eq!(version, "3.5.1");
-        assert!(url.contains("ggplot2_3.5.1.tgz"));
-        assert!(url.starts_with("https://packagemanager.posit.co/cran/latest/bin/macosx/"));
+        assert!(url.contains("ggplot2_3.5.1"));
+        assert!(url.starts_with("https://packagemanager.posit.co/cran/latest/bin/"));
         assert!(url.contains("/contrib/"));
     }
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -8,11 +8,72 @@ use std::io::Read;
 use std::path::Path;
 use std::sync::OnceLock;
 
-pub fn get_arch() -> &'static str {
-    match std::env::consts::ARCH {
-        "aarch64" => "big-sur-arm64",
-        "x86_64" => "big-sur-x86_64",
-        other => panic!("Unsupported architecture: {}", other),
+/// Returns the RSPM platform path segment and file extension for the current OS/arch.
+/// macOS: ("macosx/big-sur-arm64", "tgz")
+/// Linux: ("linux/ubuntu-jammy", "tar.gz")  — distro read from /etc/os-release
+pub fn get_platform() -> (&'static str, &'static str) {
+    static PLATFORM: OnceLock<(String, String)> = OnceLock::new();
+    let (path, ext) = PLATFORM.get_or_init(|| {
+        #[cfg(target_os = "macos")]
+        {
+            let arch = match std::env::consts::ARCH {
+                "aarch64" => "macosx/big-sur-arm64",
+                "x86_64" => "macosx/big-sur-x86_64",
+                other => panic!("Unsupported macOS architecture: {}", other),
+            };
+            (arch.to_string(), "tgz".to_string())
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let distro = linux_rspm_distro();
+            (format!("linux/{}", distro), "tar.gz".to_string())
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        {
+            panic!("Unsupported OS for RSPM package downloads");
+        }
+    });
+    (path.as_str(), ext.as_str())
+}
+
+/// Read /etc/os-release and map to an RSPM distro string.
+/// Falls back to "ubuntu-jammy" (Ubuntu 22.04) if unrecognised.
+#[cfg(target_os = "linux")]
+fn linux_rspm_distro() -> String {
+    let content = std::fs::read_to_string("/etc/os-release").unwrap_or_default();
+    let mut id = String::new();
+    let mut codename = String::new();
+    let mut version_id = String::new();
+    for line in content.lines() {
+        if let Some(v) = line.strip_prefix("ID=") {
+            id = v.trim_matches('"').to_lowercase();
+        } else if let Some(v) = line.strip_prefix("VERSION_CODENAME=") {
+            codename = v.trim_matches('"').to_lowercase();
+        } else if let Some(v) = line.strip_prefix("VERSION_ID=") {
+            version_id = v.trim_matches('"').to_string();
+        }
+    }
+    // Prefer codename (ubuntu: jammy, noble; debian: bullseye, bookworm)
+    if !codename.is_empty() && matches!(id.as_str(), "ubuntu" | "debian") {
+        return format!("{}-{}", id, codename);
+    }
+    // Fallback: map version_id for distros without VERSION_CODENAME
+    match (id.as_str(), version_id.as_str()) {
+        ("ubuntu", "22.04") => "ubuntu-jammy".to_string(),
+        ("ubuntu", "24.04") => "ubuntu-noble".to_string(),
+        ("ubuntu", "20.04") => "ubuntu-focal".to_string(),
+        ("debian", "11") => "debian-bullseye".to_string(),
+        ("debian", "12") => "debian-bookworm".to_string(),
+        ("rhel" | "centos", "7") => "centos7".to_string(),
+        ("rhel", "8") => "rhel8".to_string(),
+        ("rhel", "9") => "rhel9".to_string(),
+        _ => {
+            eprintln!(
+                "warning: unrecognised Linux distro ({} {}), defaulting to ubuntu-jammy for RSPM",
+                id, version_id
+            );
+            "ubuntu-jammy".to_string()
+        }
     }
 }
 
@@ -39,10 +100,17 @@ pub fn get_r_version() -> &'static str {
 
 /// Constructs a binary download URL from an RSPM registry base URL.
 /// registry is e.g. "https://packagemanager.posit.co/cran/2024-06-05"
-fn make_url(name: &str, version: &str, arch: &str, r_version: &str, registry: &str) -> String {
+fn make_url(
+    name: &str,
+    version: &str,
+    platform: &str,
+    ext: &str,
+    r_version: &str,
+    registry: &str,
+) -> String {
     format!(
-        "{}/bin/macosx/{}/contrib/{}/{}_{}.tgz",
-        registry, arch, r_version, name, version
+        "{}/bin/{}/contrib/{}/{}_{}.{}",
+        registry, platform, r_version, name, version, ext
     )
 }
 
@@ -50,7 +118,7 @@ fn make_url(name: &str, version: &str, arch: &str, r_version: &str, registry: &s
 pub fn build_urls_from_pairs(
     packages: &[(String, String, String)],
 ) -> Vec<(String, String, String)> {
-    let arch = get_arch();
+    let (platform, ext) = get_platform();
     let r_version = get_r_version();
     packages
         .iter()
@@ -58,7 +126,7 @@ pub fn build_urls_from_pairs(
             (
                 name.clone(),
                 version.clone(),
-                make_url(name, version, arch, r_version, registry),
+                make_url(name, version, platform, ext, r_version, registry),
             )
         })
         .collect()
@@ -72,14 +140,14 @@ pub fn build_urls(
     packages: &[String],
     index: &HashMap<String, Package>,
 ) -> Vec<(String, String, String)> {
-    let arch = get_arch();
+    let (platform, ext) = get_platform();
     let r_version = get_r_version();
 
     packages
         .iter()
         .filter_map(|name| {
             let pkg = index.get(name)?;
-            let url = make_url(name, &pkg.version, arch, r_version, RSPM_LATEST);
+            let url = make_url(name, &pkg.version, platform, ext, r_version, RSPM_LATEST);
             Some((name.clone(), pkg.version.clone(), url))
         })
         .collect()

--- a/src/r_version.rs
+++ b/src/r_version.rs
@@ -327,6 +327,7 @@ fn parse_posit_deb_listing(html: &str, arch: &str) -> Vec<RVersion> {
 }
 
 /// Parse CRAN directory listing HTML for .pkg filenames, e.g. `R-4.3.2-arm64.pkg`.
+#[cfg(target_os = "macos")]
 fn parse_cran_pkg_listing(html: &str, arch_suffix: &str) -> Vec<RVersion> {
     let suffix = format!("-{}.pkg", arch_suffix);
     let mut versions = Vec::new();

--- a/src/r_version.rs
+++ b/src/r_version.rs
@@ -44,11 +44,34 @@ pub fn find_r_installations() -> Vec<RInstallation> {
         }
     }
 
+    // macOS: Homebrew
+    #[cfg(target_os = "macos")]
+    {
+        let bin = PathBuf::from("/opt/homebrew/bin");
+        if bin.join("R").exists() {
+            bin_dirs.push(bin);
+        }
+    }
+
     // Common PATH locations
-    for dir in &["/usr/local/bin", "/usr/bin", "/opt/homebrew/bin"] {
+    for dir in &["/usr/local/bin", "/usr/bin"] {
         let bin = PathBuf::from(dir);
         if bin.join("R").exists() {
             bin_dirs.push(bin);
+        }
+    }
+
+    // Linux: Posit/rig managed installations at /opt/R/{version}/bin/
+    #[cfg(target_os = "linux")]
+    {
+        let opt_r = Path::new("/opt/R");
+        if let Ok(entries) = std::fs::read_dir(opt_r) {
+            for entry in entries.flatten() {
+                let bin = entry.path().join("bin");
+                if bin.join("R").exists() {
+                    bin_dirs.push(bin);
+                }
+            }
         }
     }
 

--- a/src/r_version.rs
+++ b/src/r_version.rs
@@ -210,6 +210,7 @@ fn r_managed_dir() -> PathBuf {
         .join("r")
 }
 
+#[cfg(target_os = "macos")]
 fn cran_arch() -> &'static str {
     match std::env::consts::ARCH {
         "aarch64" => "big-sur-arm64",
@@ -217,6 +218,7 @@ fn cran_arch() -> &'static str {
     }
 }
 
+#[cfg(target_os = "macos")]
 fn cran_arch_suffix() -> &'static str {
     match std::env::consts::ARCH {
         "aarch64" => "arm64",
@@ -224,8 +226,18 @@ fn cran_arch_suffix() -> &'static str {
     }
 }
 
-/// Fetch available R versions for this platform from the CRAN directory listing.
+/// Fetch available R versions for this platform.
 fn fetch_available_r_versions() -> Result<Vec<RVersion>, String> {
+    #[cfg(target_os = "macos")]
+    return fetch_available_r_versions_macos();
+    #[cfg(target_os = "linux")]
+    return fetch_available_r_versions_linux();
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    Err("automatic R installation is not supported on this platform".to_string())
+}
+
+#[cfg(target_os = "macos")]
+fn fetch_available_r_versions_macos() -> Result<Vec<RVersion>, String> {
     let url = format!(
         "https://cran.r-project.org/bin/macosx/{}/base/",
         cran_arch()
@@ -240,6 +252,78 @@ fn fetch_available_r_versions() -> Result<Vec<RVersion>, String> {
     } else {
         Ok(versions)
     }
+}
+
+/// Read /etc/os-release and return the Posit CDN distro string, e.g. "ubuntu-2204".
+#[cfg(target_os = "linux")]
+fn linux_posit_distro() -> String {
+    let content = std::fs::read_to_string("/etc/os-release").unwrap_or_default();
+    let mut id = String::new();
+    let mut version_id = String::new();
+    for line in content.lines() {
+        if let Some(v) = line.strip_prefix("ID=") {
+            id = v.trim_matches('"').to_lowercase();
+        } else if let Some(v) = line.strip_prefix("VERSION_ID=") {
+            version_id = v.trim_matches('"').replace('.', "");
+        }
+    }
+    match id.as_str() {
+        "ubuntu" | "debian" if !version_id.is_empty() => format!("{}-{}", id, version_id),
+        _ => {
+            eprintln!(
+                "warning: unrecognised Linux distro ({} {}), defaulting to ubuntu-2204 for Posit CDN",
+                id, version_id
+            );
+            "ubuntu-2204".to_string()
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_posit_arch() -> &'static str {
+    match std::env::consts::ARCH {
+        "aarch64" => "arm64",
+        _ => "amd64",
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn fetch_available_r_versions_linux() -> Result<Vec<RVersion>, String> {
+    let distro = linux_posit_distro();
+    let arch = linux_posit_arch();
+    let url = format!("https://cdn.posit.co/r/{}/pkgs/", distro);
+    let body = reqwest::blocking::get(&url)
+        .map_err(|e| format!("failed to fetch Posit R version list: {}", e))?
+        .text()
+        .map_err(|e| format!("failed to read Posit R version list: {}", e))?;
+    let versions = parse_posit_deb_listing(&body, arch);
+    if versions.is_empty() {
+        Err(format!(
+            "no R versions found for {} on Posit CDN ({})",
+            distro, url
+        ))
+    } else {
+        Ok(versions)
+    }
+}
+
+/// Parse Posit CDN directory listing HTML for .deb filenames, e.g. `r-4.3.2_1_amd64.deb`.
+#[cfg(target_os = "linux")]
+fn parse_posit_deb_listing(html: &str, arch: &str) -> Vec<RVersion> {
+    let suffix = format!("_1_{}.deb", arch);
+    let mut versions = Vec::new();
+    for part in html.split("r-") {
+        let Some(end) = part.find(suffix.as_str()) else {
+            continue;
+        };
+        let version_str = &part[..end];
+        if let Some(v) = RVersion::parse(version_str) {
+            versions.push(v);
+        }
+    }
+    versions.sort_by(|a, b| b.cmp(a));
+    versions.dedup_by(|a, b| a == b);
+    versions
 }
 
 /// Parse CRAN directory listing HTML for .pkg filenames, e.g. `R-4.3.2-arm64.pkg`.
@@ -279,6 +363,7 @@ fn resolve_version_to_download(
 }
 
 /// Download the R .pkg for `version` to a temp file, with a progress bar.
+#[cfg(target_os = "macos")]
 fn download_r_pkg(version: &RVersion) -> Result<PathBuf, String> {
     let url = format!(
         "https://cran.r-project.org/bin/macosx/{}/base/R-{}-{}.pkg",
@@ -362,9 +447,126 @@ fn extract_r_pkg(pkg_path: &Path, dest_dir: &Path) -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(not(target_os = "macos"))]
-fn extract_r_pkg(_pkg_path: &Path, _dest_dir: &Path) -> Result<(), String> {
-    Err("automatic R installation is only supported on macOS currently".to_string())
+/// Download the R .deb for `version` to a temp file, with a progress bar.
+#[cfg(target_os = "linux")]
+fn download_r_deb(version: &RVersion) -> Result<PathBuf, String> {
+    let distro = linux_posit_distro();
+    let arch = linux_posit_arch();
+    let url = format!(
+        "https://cdn.posit.co/r/{}/pkgs/r-{}_1_{}.deb",
+        distro, version, arch
+    );
+
+    let response = reqwest::blocking::get(&url)
+        .map_err(|e| format!("failed to download R {}: {}", version, e))?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "failed to download R {} (HTTP {})\n       URL: {}",
+            version,
+            response.status(),
+            url
+        ));
+    }
+
+    let total = response.content_length().unwrap_or(0);
+    let pb = ProgressBar::new(total);
+    pb.set_style(
+        ProgressStyle::with_template(
+            "  Downloading R {msg} [{wide_bar:.green/dim}] {bytes:>10}/{total_bytes:<10}",
+        )
+        .unwrap()
+        .progress_chars("━━╌"),
+    );
+    pb.set_message(version.to_string());
+
+    let mut src = pb.wrap_read(response);
+    let mut bytes = Vec::new();
+    src.read_to_end(&mut bytes)
+        .map_err(|e| format!("failed to read R download: {}", e))?;
+    pb.finish_and_clear();
+
+    let tmp = std::env::temp_dir().join(format!("ruv-R-{}-{}.deb", version, arch));
+    std::fs::write(&tmp, &bytes).map_err(|e| format!("failed to write R deb to temp: {}", e))?;
+    Ok(tmp)
+}
+
+/// Extract a Posit .deb into `dest_dir` using `ar` + `tar`.
+/// Requires `binutils` (provides `ar`) — present on all standard Linux distros.
+#[cfg(target_os = "linux")]
+fn extract_r_deb(deb_path: &Path, dest_dir: &Path) -> Result<(), String> {
+    let work_dir = std::env::temp_dir().join(format!("ruv-deb-{}", std::process::id()));
+    std::fs::create_dir_all(&work_dir).map_err(|e| format!("failed to create temp dir: {}", e))?;
+
+    // Step 1: ar x file.deb — extracts debian-binary, control.tar.*, data.tar.*
+    let status = std::process::Command::new("ar")
+        .args(["x", &deb_path.to_string_lossy()])
+        .current_dir(&work_dir)
+        .status()
+        .map_err(|e| format!("failed to run ar (is binutils installed?): {}", e))?;
+    if !status.success() {
+        return Err("ar extraction of .deb failed".to_string());
+    }
+
+    // Step 2: find data.tar.* (xz, gz, or zst depending on distro)
+    let data_tar = find_deb_data_tar(&work_dir)?;
+
+    // Step 3: extract data tarball into dest_dir
+    let status = std::process::Command::new("tar")
+        .args([
+            "xf",
+            &data_tar.to_string_lossy(),
+            "-C",
+            &dest_dir.to_string_lossy(),
+        ])
+        .status()
+        .map_err(|e| format!("failed to run tar: {}", e))?;
+    if !status.success() {
+        return Err("tar extraction of R deb data failed".to_string());
+    }
+
+    let _ = std::fs::remove_dir_all(&work_dir);
+    Ok(())
+}
+
+/// Find data.tar.* inside an extracted .deb working directory.
+#[cfg(target_os = "linux")]
+fn find_deb_data_tar(work_dir: &Path) -> Result<PathBuf, String> {
+    for name in &["data.tar.xz", "data.tar.gz", "data.tar.zst"] {
+        let p = work_dir.join(name);
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+    Err(format!(
+        "could not find data.tar.* in extracted .deb at {}",
+        work_dir.display()
+    ))
+}
+
+/// Download and extract R for the current platform into `install_dir`.
+fn download_and_extract_r(version: &RVersion, install_dir: &Path) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let pkg_path = download_r_pkg(version)?;
+        println!("  Installing R {}...", version);
+        extract_r_pkg(&pkg_path, install_dir)?;
+        let _ = std::fs::remove_file(&pkg_path);
+        Ok(())
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let deb_path = download_r_deb(version)?;
+        println!("  Installing R {}...", version);
+        extract_r_deb(&deb_path, install_dir)?;
+        let _ = std::fs::remove_file(&deb_path);
+        Ok(())
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = (version, install_dir);
+        Err("automatic R installation is not supported on this platform".to_string())
+    }
 }
 
 /// Find the R framework Payload file inside an expanded .pkg directory.
@@ -430,10 +632,7 @@ pub fn auto_install_r(constraint: &str) -> Result<RInstallation, String> {
     std::fs::create_dir_all(&install_dir)
         .map_err(|e| format!("failed to create R install dir: {}", e))?;
 
-    let pkg_path = download_r_pkg(&version)?;
-    println!("  Installing R {}...", version);
-    extract_r_pkg(&pkg_path, &install_dir)?;
-    let _ = std::fs::remove_file(&pkg_path);
+    download_and_extract_r(&version, &install_dir)?;
 
     // Find the R binary inside the extracted framework and create a stable bin/ symlink
     let r_bin_dir = find_r_bin_in_dir(&install_dir).ok_or_else(|| {
@@ -670,6 +869,19 @@ mod tests {
             .collect();
         let v = resolve_version_to_download(">=4.4", &available).unwrap();
         assert_eq!(v.to_string(), "4.5.1"); // highest satisfying >=4.4
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_parse_posit_deb_listing_amd64() {
+        let html = r#"
+            <a href="r-4.3.2_1_amd64.deb">r-4.3.2_1_amd64.deb</a>
+            <a href="r-4.4.0_1_amd64.deb">r-4.4.0_1_amd64.deb</a>
+            <a href="r-4.5.1_1_amd64.deb">r-4.5.1_1_amd64.deb</a>
+        "#;
+        let versions = parse_posit_deb_listing(html, "amd64");
+        let strs: Vec<String> = versions.iter().map(|v| v.to_string()).collect();
+        assert_eq!(strs, vec!["4.5.1", "4.4.0", "4.3.2"]);
     }
 
     #[test]

--- a/src/r_version.rs
+++ b/src/r_version.rs
@@ -839,6 +839,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "macos")]
     fn test_parse_cran_pkg_listing_arm64() {
         let html = r#"
             <a href="R-4.3.2-arm64.pkg">R-4.3.2-arm64.pkg</a>


### PR DESCRIPTION
- **docs: add Linux build and Docker verification plan**
- **feat: Linux compatibility (#50)**
- **feat: add Linux aarch64 musl build target**
- **docs: update linux_build.md with aarch64 and Docker platform flag**
- **feat: Linux R auto-download via Posit CDN .deb binaries**
- **docs: add DEBIAN_FRONTEND=noninteractive to Docker apt commands**
- **chore: bump version to 0.1.0-alpha.4**


Linux compatibility (0.1.0-alpha.4)

install.sh
- Shebang changed to #!/bin/sh — works under dash, busybox, any POSIX shell
- [[ replaced with case statement (bash-specific syntax removed)
- Added aarch64 Linux target (aarch64-unknown-linux-musl)

Musl static builds
- Switched reqwest from native-tls → rustls (required for musl — can't link OpenSSL statically)
- CI release matrix now builds x86_64-unknown-linux-musl and aarch64-unknown-linux-musl instead of the glibc-linked
x86_64-unknown-linux-gnu
- Binaries run on Ubuntu 20.04, 22.04, 24.04, Alpine, and any Linux kernel ≥ 3.2

Package installs on Linux
- get_arch() panicked on Linux — replaced with get_platform() which reads /etc/os-release and maps to RSPM distro path
(linux/ubuntu-jammy, etc.)
- Handles .tgz (macOS) vs .tar.gz (Linux) extension difference

R version management on Linux
- find_r_installations() now probes /opt/R/*/bin/ (Posit/rig installs); /opt/homebrew/bin gated to macOS only
- auto_install_r downloads Posit pre-built .deb binaries from cdn.posit.co/r/{distro}/pkgs/ — same binaries rig uses, no sudo
required. Extracts via ar x + tar xf
