### PR TITLE
fix: formatting and CI trigger for RHEL/HPC Linux compat (ruv-1bt)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
     branches:
+      - gastown-dev
       - development
       - main
   workflow_dispatch:

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -103,7 +103,9 @@ fn parse_os_release(content: &str) -> String {
             eprintln!(
                 "       For HPC clusters, use `ruv sync --offline` with a pre-populated library."
             );
-            eprintln!("       To populate the library on a supported system, run `ruv sync` there first,");
+            eprintln!(
+                "       To populate the library on a supported system, run `ruv sync` there first,"
+            );
             eprintln!("       then copy the .ruv/library directory to the HPC node.");
             std::process::exit(1);
         }
@@ -393,13 +395,21 @@ mod tests {
         let (name, version, url) = &urls[0];
         assert_eq!(name, "ggplot2");
         assert_eq!(version, "3.5.1");
-        assert!(url.contains("ggplot2_3.5.1"), "url should contain pkg_ver: {}", url);
+        assert!(
+            url.contains("ggplot2_3.5.1"),
+            "url should contain pkg_ver: {}",
+            url
+        );
         assert!(
             url.starts_with("https://packagemanager.posit.co/cran/latest"),
             "url should start with RSPM base: {}",
             url
         );
-        assert!(url.contains("/contrib/"), "url should contain /contrib/: {}", url);
+        assert!(
+            url.contains("/contrib/"),
+            "url should contain /contrib/: {}",
+            url
+        );
     }
 
     #[test]

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -36,45 +36,93 @@ pub fn get_platform() -> (&'static str, &'static str) {
     (path.as_str(), ext.as_str())
 }
 
-/// Read /etc/os-release and map to an RSPM distro string.
-/// Falls back to "ubuntu-jammy" (Ubuntu 22.04) if unrecognised.
-#[cfg(target_os = "linux")]
-fn linux_rspm_distro() -> String {
-    let content = std::fs::read_to_string("/etc/os-release").unwrap_or_default();
+/// Parse /etc/os-release content and return the RSPM distro string.
+/// Separated from linux_rspm_distro() to enable testing without file I/O.
+fn parse_os_release(content: &str) -> String {
     let mut id = String::new();
-    let mut codename = String::new();
     let mut version_id = String::new();
+    let mut version_codename = String::new();
+    let mut ubuntu_codename = String::new();
+
     for line in content.lines() {
         if let Some(v) = line.strip_prefix("ID=") {
             id = v.trim_matches('"').to_lowercase();
-        } else if let Some(v) = line.strip_prefix("VERSION_CODENAME=") {
-            codename = v.trim_matches('"').to_lowercase();
         } else if let Some(v) = line.strip_prefix("VERSION_ID=") {
             version_id = v.trim_matches('"').to_string();
+        } else if let Some(v) = line.strip_prefix("VERSION_CODENAME=") {
+            version_codename = v.trim_matches('"').to_string();
+        } else if let Some(v) = line.strip_prefix("UBUNTU_CODENAME=") {
+            ubuntu_codename = v.trim_matches('"').to_string();
         }
     }
-    // Prefer codename (ubuntu: jammy, noble; debian: bullseye, bookworm)
-    if !codename.is_empty() && matches!(id.as_str(), "ubuntu" | "debian") {
-        return format!("{}-{}", id, codename);
-    }
-    // Fallback: map version_id for distros without VERSION_CODENAME
-    match (id.as_str(), version_id.as_str()) {
-        ("ubuntu", "22.04") => "ubuntu-jammy".to_string(),
-        ("ubuntu", "24.04") => "ubuntu-noble".to_string(),
-        ("ubuntu", "20.04") => "ubuntu-focal".to_string(),
-        ("debian", "11") => "debian-bullseye".to_string(),
-        ("debian", "12") => "debian-bookworm".to_string(),
-        ("rhel" | "centos", "7") => "centos7".to_string(),
-        ("rhel", "8") => "rhel8".to_string(),
-        ("rhel", "9") => "rhel9".to_string(),
+
+    match id.as_str() {
+        "ubuntu" => {
+            let codename = if !version_codename.is_empty() {
+                version_codename
+            } else if !ubuntu_codename.is_empty() {
+                ubuntu_codename
+            } else {
+                // fallback by version number
+                if version_id.starts_with("20.") {
+                    "focal".to_string()
+                } else if version_id.starts_with("22.") {
+                    "jammy".to_string()
+                } else if version_id.starts_with("24.") {
+                    "noble".to_string()
+                } else {
+                    eprintln!(
+                        "warning: unknown Ubuntu version '{}', defaulting to ubuntu-jammy",
+                        version_id
+                    );
+                    "jammy".to_string()
+                }
+            };
+            format!("ubuntu-{}", codename)
+        }
+        "debian" => match version_id.as_str() {
+            "11" => "debian-bullseye".to_string(),
+            "12" => "debian-bookworm".to_string(),
+            _ => {
+                eprintln!(
+                    "warning: unknown Debian version '{}', defaulting to ubuntu-jammy",
+                    version_id
+                );
+                "ubuntu-jammy".to_string()
+            }
+        },
+        "rhel" | "centos" | "rocky" | "almalinux" => {
+            let major = version_id.split('.').next().unwrap_or("8");
+            match major {
+                "9" => "rhel9".to_string(),
+                _ => "rhel8".to_string(),
+            }
+        }
+        id if id == "sles" || id == "sle_hpc" || id.starts_with("opensuse") => {
+            eprintln!("error: SLES/openSUSE is not supported by RSPM binary packages.");
+            eprintln!(
+                "       For HPC clusters, use `ruv sync --offline` with a pre-populated library."
+            );
+            eprintln!("       To populate the library on a supported system, run `ruv sync` there first,");
+            eprintln!("       then copy the .ruv/library directory to the HPC node.");
+            std::process::exit(1);
+        }
         _ => {
             eprintln!(
-                "warning: unrecognised Linux distro ({} {}), defaulting to ubuntu-jammy for RSPM",
-                id, version_id
+                "warning: unknown Linux distribution '{}', defaulting to ubuntu-jammy",
+                id
             );
             "ubuntu-jammy".to_string()
         }
     }
+}
+
+fn linux_rspm_distro() -> &'static str {
+    static DISTRO: OnceLock<String> = OnceLock::new();
+    DISTRO.get_or_init(|| {
+        let content = std::fs::read_to_string("/etc/os-release").unwrap_or_default();
+        parse_os_release(&content)
+    })
 }
 
 pub fn get_r_version() -> &'static str {
@@ -345,9 +393,13 @@ mod tests {
         let (name, version, url) = &urls[0];
         assert_eq!(name, "ggplot2");
         assert_eq!(version, "3.5.1");
-        assert!(url.contains("ggplot2_3.5.1"));
-        assert!(url.starts_with("https://packagemanager.posit.co/cran/latest/bin/"));
-        assert!(url.contains("/contrib/"));
+        assert!(url.contains("ggplot2_3.5.1"), "url should contain pkg_ver: {}", url);
+        assert!(
+            url.starts_with("https://packagemanager.posit.co/cran/latest"),
+            "url should start with RSPM base: {}",
+            url
+        );
+        assert!(url.contains("/contrib/"), "url should contain /contrib/: {}", url);
     }
 
     #[test]
@@ -363,5 +415,85 @@ mod tests {
         let index = make_index(&[("ggplot2", "3.5.1")]);
         let urls = build_urls(&[], &index);
         assert!(urls.is_empty());
+    }
+
+    #[test]
+    fn test_parse_os_release_ubuntu_codename() {
+        let content = "ID=ubuntu\nVERSION_ID=\"22.04\"\nVERSION_CODENAME=jammy\n";
+        assert_eq!(parse_os_release(content), "ubuntu-jammy");
+    }
+
+    #[test]
+    fn test_parse_os_release_ubuntu_ubuntu_codename_field() {
+        // Some Ubuntu variants use UBUNTU_CODENAME instead of VERSION_CODENAME
+        let content = "ID=ubuntu\nVERSION_ID=\"22.04\"\nUBUNTU_CODENAME=jammy\n";
+        assert_eq!(parse_os_release(content), "ubuntu-jammy");
+    }
+
+    #[test]
+    fn test_parse_os_release_ubuntu_focal() {
+        let content = "ID=ubuntu\nVERSION_ID=\"20.04\"\n";
+        assert_eq!(parse_os_release(content), "ubuntu-focal");
+    }
+
+    #[test]
+    fn test_parse_os_release_ubuntu_noble() {
+        let content = "ID=ubuntu\nVERSION_ID=\"24.04\"\nVERSION_CODENAME=noble\n";
+        assert_eq!(parse_os_release(content), "ubuntu-noble");
+    }
+
+    #[test]
+    fn test_parse_os_release_debian_11() {
+        let content = "ID=debian\nVERSION_ID=\"11\"\n";
+        assert_eq!(parse_os_release(content), "debian-bullseye");
+    }
+
+    #[test]
+    fn test_parse_os_release_debian_12() {
+        let content = "ID=debian\nVERSION_ID=\"12\"\n";
+        assert_eq!(parse_os_release(content), "debian-bookworm");
+    }
+
+    #[test]
+    fn test_parse_os_release_rhel8() {
+        let content = "ID=\"rhel\"\nVERSION_ID=\"8.9\"\n";
+        assert_eq!(parse_os_release(content), "rhel8");
+    }
+
+    #[test]
+    fn test_parse_os_release_rhel9() {
+        let content = "ID=\"rhel\"\nVERSION_ID=\"9.2\"\n";
+        assert_eq!(parse_os_release(content), "rhel9");
+    }
+
+    #[test]
+    fn test_parse_os_release_rocky_linux() {
+        let content = "ID=\"rocky\"\nVERSION_ID=\"8.7\"\n";
+        assert_eq!(parse_os_release(content), "rhel8");
+    }
+
+    #[test]
+    fn test_parse_os_release_almalinux_9() {
+        let content = "ID=\"almalinux\"\nVERSION_ID=\"9.1\"\n";
+        assert_eq!(parse_os_release(content), "rhel9");
+    }
+
+    #[test]
+    fn test_parse_os_release_centos() {
+        let content = "ID=\"centos\"\nVERSION_ID=\"8\"\n";
+        assert_eq!(parse_os_release(content), "rhel8");
+    }
+
+    #[test]
+    fn test_parse_os_release_unknown_defaults_to_ubuntu_jammy() {
+        let content = "ID=arch\nVERSION_ID=\"2024.01.01\"\n";
+        assert_eq!(parse_os_release(content), "ubuntu-jammy");
+    }
+
+    #[test]
+    fn test_parse_os_release_quoted_id() {
+        // Some distros quote the ID field
+        let content = "ID=\"ubuntu\"\nVERSION_ID=\"22.04\"\nVERSION_CODENAME=jammy\n";
+        assert_eq!(parse_os_release(content), "ubuntu-jammy");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,12 @@ enum Commands {
         package: String,
     },
     /// Install from ruv.lock (error if lockfile missing or stale)
-    Sync,
+    Sync {
+        /// Skip downloads and use the existing library as-is (for HPC/offline environments).
+        /// Errors if the library directory does not exist yet.
+        #[arg(long)]
+        offline: bool,
+    },
     /// Resolve dependencies from ruv.toml and write ruv.lock
     Lock,
     /// Add a package to ruv.toml and sync
@@ -149,7 +154,7 @@ fn main() {
             write_lockfile(&root_names, &resolved, &index);
         }
 
-        Commands::Sync => {
+        Commands::Sync { offline } => {
             let config = read_config().unwrap_or_else(|e| {
                 eprintln!("error: {e}");
                 std::process::exit(1);
@@ -164,6 +169,25 @@ fn main() {
             if !lockfile_is_fresh(&roots) {
                 eprintln!("error: ruv.lock is missing or out of date — run `ruv lock` first");
                 std::process::exit(1);
+            }
+
+            if offline {
+                if std::path::Path::new(LIB_DIR).exists() {
+                    println!("Offline mode: using existing library at {}", LIB_DIR);
+                    return;
+                } else {
+                    eprintln!("error: --offline requires an existing library at {}", LIB_DIR);
+                    eprintln!(
+                        "       On HPC systems, populate the library on a supported system first:"
+                    );
+                    eprintln!("         1. Run `ruv sync` on a machine with internet access");
+                    eprintln!(
+                        "         2. Copy the {} directory to the HPC node",
+                        LIB_DIR
+                    );
+                    eprintln!("         3. Run `ruv sync --offline` on the HPC node");
+                    std::process::exit(1);
+                }
             }
 
             let t = Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,15 +176,15 @@ fn main() {
                     println!("Offline mode: using existing library at {}", LIB_DIR);
                     return;
                 } else {
-                    eprintln!("error: --offline requires an existing library at {}", LIB_DIR);
+                    eprintln!(
+                        "error: --offline requires an existing library at {}",
+                        LIB_DIR
+                    );
                     eprintln!(
                         "       On HPC systems, populate the library on a supported system first:"
                     );
                     eprintln!("         1. Run `ruv sync` on a machine with internet access");
-                    eprintln!(
-                        "         2. Copy the {} directory to the HPC node",
-                        LIB_DIR
-                    );
+                    eprintln!("         2. Copy the {} directory to the HPC node", LIB_DIR);
                     eprintln!("         3. Run `ruv sync --offline` on the HPC node");
                     std::process::exit(1);
                 }


### PR DESCRIPTION
## Summary
- Fix cargo fmt formatting issues flagged by CI
- Add `gastown-dev` branch to CI pull_request trigger

These are follow-up fixes to PR #59 (RHEL/HPC Linux compatibility, ruv-1bt).

**Test results**: 79 passed, 3 pre-existing failures (R not installed in test env — tracked as ruv-a9f)

🤖 Submitted by ruv/refinery