### PR TITLE
fix: avoid R invocation in unit tests; ignore Gas Town dirs (ruv-a9f)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Gas Town runtime state (local only, not part of the project)
+/.beads/
+/.claude/
+/.runtime/
+
 # Rust
 /target
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -425,7 +425,13 @@ mod tests {
     #[test]
     fn test_build_urls_format() {
         let index = make_index(&[("ggplot2", "3.5.1")]);
-        let urls = build_urls_with(&["ggplot2".to_string()], &index, "macosx/big-sur-arm64", "tgz", "4.4");
+        let urls = build_urls_with(
+            &["ggplot2".to_string()],
+            &index,
+            "macosx/big-sur-arm64",
+            "tgz",
+            "4.4",
+        );
         assert_eq!(urls.len(), 1);
         let (name, version, url) = &urls[0];
         assert_eq!(name, "ggplot2");

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -194,8 +194,16 @@ pub fn build_urls(
     index: &HashMap<String, Package>,
 ) -> Vec<(String, String, String)> {
     let (platform, ext) = get_platform();
-    let r_version = get_r_version();
+    build_urls_with(packages, index, platform, ext, get_r_version())
+}
 
+fn build_urls_with(
+    packages: &[String],
+    index: &HashMap<String, Package>,
+    platform: &str,
+    ext: &str,
+    r_version: &str,
+) -> Vec<(String, String, String)> {
     packages
         .iter()
         .filter_map(|name| {
@@ -417,7 +425,7 @@ mod tests {
     #[test]
     fn test_build_urls_format() {
         let index = make_index(&[("ggplot2", "3.5.1")]);
-        let urls = build_urls(&["ggplot2".to_string()], &index);
+        let urls = build_urls_with(&["ggplot2".to_string()], &index, "macosx/big-sur-arm64", "tgz", "4.4");
         assert_eq!(urls.len(), 1);
         let (name, version, url) = &urls[0];
         assert_eq!(name, "ggplot2");
@@ -442,7 +450,13 @@ mod tests {
     #[test]
     fn test_build_urls_drops_missing_packages() {
         let index = make_index(&[("ggplot2", "3.5.1")]);
-        let urls = build_urls(&["ggplot2".to_string(), "not-in-index".to_string()], &index);
+        let urls = build_urls_with(
+            &["ggplot2".to_string(), "not-in-index".to_string()],
+            &index,
+            "macosx/big-sur-arm64",
+            "tgz",
+            "4.4",
+        );
         assert_eq!(urls.len(), 1);
         assert_eq!(urls[0].0, "ggplot2");
     }
@@ -450,7 +464,7 @@ mod tests {
     #[test]
     fn test_build_urls_empty_input() {
         let index = make_index(&[("ggplot2", "3.5.1")]);
-        let urls = build_urls(&[], &index);
+        let urls = build_urls_with(&[], &index, "macosx/big-sur-arm64", "tgz", "4.4");
         assert!(urls.is_empty());
     }
 


### PR DESCRIPTION
## Summary
- Fix `build_urls` unit tests to avoid invoking R (tests now pass without R installed)
- Add `.beads/`, `.claude/`, `.runtime/` to `.gitignore` (Gas Town runtime dirs)

**Test results**: 59 passed, 0 failed ✅ (pre-existing R failures resolved)

🤖 Submitted by ruv/refinery