### PR TITLE
fix: add 'main' to pull_request trigger branches in CI (ruv-rz5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - development
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Automated merge from polecat branch.

- **Issue**: ruv-rz5
- **Polecat**: onyx
- **Branch**: polecat/onyx/ruv-rz5@mmwop1fv
- **Tests**: Pre-existing failure noted (ruv-mbz: test_command misconfigured for Rust repo)

## What changed
Adds 'main' to the pull_request trigger branches list in .github/workflows/ci.yml so PRs from development→main run CI before merge.

## Issues closed
- ruv-rz5: Fix CI: add 'main' to pull_request trigger branches

## Testing
CI workflow now triggers on PRs targeting main branch.

---
*Created by Gas Town Refinery*