### PR TITLE
feat: add pre-commit hooks for cargo fmt and cargo clippy (ruv-30t)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Gas Town runtime
+/.beads/
+/.claude/
+/.runtime/
+
 # Rust
 /target
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        description: Check formatting with rustfmt
+        entry: cargo fmt -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+      - id: cargo-clippy
+        name: cargo clippy
+        description: Run clippy linter
+        entry: cargo clippy -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -125,6 +125,21 @@ cargo build
 cargo test
 ```
 
+### Pre-commit hooks
+
+Install [pre-commit](https://pre-commit.com) and set up the hooks to catch formatting and lint issues before push:
+
+```sh
+pip install pre-commit
+pre-commit install
+```
+
+The hooks run `cargo fmt --check` and `cargo clippy` on every commit. To run them manually:
+
+```sh
+pre-commit run --all-files
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Automated merge from polecat branch.

- **Issue**: ruv-30t
- **Polecat**: obsidian
- **Branch**: polecat/obsidian/ruv-30t@mmwoox7r
- **Tests**: Pre-existing failure (ruv-mbz: test_command misconfigured for Rust repo)

## What changed
Adds .pre-commit-config.yaml with hooks for cargo fmt --check and cargo clippy so formatting and lint issues are caught locally before push. Updates dev setup instructions.

## Issues closed
- ruv-30t: Add pre-commit hooks: cargo fmt and cargo clippy

## Testing
Run `pre-commit install` then make a commit — fmt and clippy checks fire locally.

---
*Created by Gas Town Refinery*