### PR TITLE
feat: ruv add auto-locks, add ruv remove command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,11 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get install -y musl-tools
 
-      - name: Install musl tools (Linux aarch64)
+      - name: Install cross (Linux aarch64 musl)
         if: matrix.target == 'aarch64-unknown-linux-musl'
-        run: |
-          sudo apt-get install -y gcc-aarch64-linux-gnu musl-tools
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -48,7 +48,12 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Build binary
+        if: matrix.target != 'aarch64-unknown-linux-musl'
         run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Build binary (cross)
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        run: cross build --release --target ${{ matrix.target }}
 
       - name: Create tarball
         run: |

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,11 @@ pub enum AddDependencyResult {
     AlreadyPresent,
 }
 
+pub enum RemoveDependencyResult {
+    Removed,
+    NotFound,
+}
+
 pub fn add_dependency(dep: &str) -> Result<AddDependencyResult, String> {
     let text = std::fs::read_to_string(CONFIG_FILE).map_err(|e| {
         if e.kind() == ErrorKind::NotFound {
@@ -68,6 +73,86 @@ pub fn add_dependency(dep: &str) -> Result<AddDependencyResult, String> {
     } else {
         Ok(AddDependencyResult::AlreadyPresent)
     }
+}
+
+pub fn remove_dependency(dep: &str) -> Result<RemoveDependencyResult, String> {
+    let text = std::fs::read_to_string(CONFIG_FILE).map_err(|e| {
+        if e.kind() == ErrorKind::NotFound {
+            format!(
+                "could not find {} in this directory — run `ruv init` first",
+                CONFIG_FILE
+            )
+        } else {
+            format!("failed to read {}: {}", CONFIG_FILE, e)
+        }
+    })?;
+    let (updated, removed) = remove_dependency_from_toml_text(&text, dep)?;
+    if !removed {
+        return Ok(RemoveDependencyResult::NotFound);
+    }
+    std::fs::write(CONFIG_FILE, updated)
+        .map_err(|e| format!("failed to write {}: {}", CONFIG_FILE, e))?;
+    Ok(RemoveDependencyResult::Removed)
+}
+
+fn remove_dependency_from_toml_text(text: &str, dep: &str) -> Result<(String, bool), String> {
+    let root: toml::Value =
+        toml::from_str(text).map_err(|e| format!("failed to parse {}: {}", CONFIG_FILE, e))?;
+    let deps_array = root
+        .get("project")
+        .and_then(|v| v.get("dependencies"))
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| {
+            format!(
+                "invalid {}: missing [project].dependencies array",
+                CONFIG_FILE
+            )
+        })?;
+    let existing: Vec<String> = deps_array
+        .iter()
+        .map(|v| {
+            v.as_str().map(|s| s.to_string()).ok_or_else(|| {
+                format!(
+                    "invalid {}: dependencies entries must be strings",
+                    CONFIG_FILE
+                )
+            })
+        })
+        .collect::<Result<_, _>>()?;
+
+    let target_name = parse_dep_name(dep);
+    let found = existing.iter().any(|e| parse_dep_name(e) == target_name);
+    if !found {
+        return Ok((text.to_string(), false));
+    }
+
+    let remaining: Vec<String> = existing
+        .into_iter()
+        .filter(|e| parse_dep_name(e) != target_name)
+        .collect();
+
+    let (body_start, body_end) = find_project_body_range(text)?;
+    let dep_field = find_dependencies_field(text, body_start, body_end).ok_or_else(|| {
+        format!(
+            "invalid {}: missing [project].dependencies array",
+            CONFIG_FILE
+        )
+    })?;
+
+    let key_indent = &text[dep_field.key_indent_start..dep_field.key_indent_end];
+    let item_indent = if text[dep_field.open_bracket..=dep_field.close_bracket].contains('\n') {
+        infer_item_indent(text, dep_field.open_bracket, dep_field.close_bracket)
+            .unwrap_or_else(|| format!("{}    ", key_indent))
+    } else {
+        format!("{}    ", key_indent)
+    };
+
+    let replacement = render_dependencies_array(&remaining, true, key_indent, &item_indent);
+    let mut out = String::with_capacity(text.len());
+    out.push_str(&text[..dep_field.open_bracket]);
+    out.push_str(&replacement);
+    out.push_str(&text[dep_field.close_bracket + 1..]);
+    Ok((out, true))
 }
 
 fn default_config_toml(project_name: &str) -> String {
@@ -473,6 +558,43 @@ mod tests {
     fn test_parse_dep_name_preserves_dots_and_dashes() {
         assert_eq!(parse_dep_name("data.table"), "data.table");
         assert_eq!(parse_dep_name("R6"), "R6");
+    }
+
+    #[test]
+    fn test_remove_dependency_basic() {
+        let text = "[project]\nname = \"x\"\nversion = \"0.1.0\"\ndependencies = [\n    \"ggplot2\",\n    \"dplyr\",\n]\n";
+        let (updated, removed) = remove_dependency_from_toml_text(text, "ggplot2").unwrap();
+        assert!(removed);
+        assert!(!updated.contains("\"ggplot2\""));
+        assert!(updated.contains("\"dplyr\""));
+    }
+
+    #[test]
+    fn test_remove_dependency_not_found() {
+        let text =
+            "[project]\nname = \"x\"\nversion = \"0.1.0\"\ndependencies = [\n    \"ggplot2\",\n]\n";
+        let (updated, removed) = remove_dependency_from_toml_text(text, "dplyr").unwrap();
+        assert!(!removed);
+        assert_eq!(updated, text);
+    }
+
+    #[test]
+    fn test_remove_dependency_last_item_leaves_empty_array() {
+        let text =
+            "[project]\nname = \"x\"\nversion = \"0.1.0\"\ndependencies = [\n    \"ggplot2\",\n]\n";
+        let (updated, removed) = remove_dependency_from_toml_text(text, "ggplot2").unwrap();
+        assert!(removed);
+        assert!(!updated.contains("\"ggplot2\""));
+        assert!(updated.contains("dependencies = [\n]"));
+    }
+
+    #[test]
+    fn test_remove_dependency_matches_by_name_ignores_constraint() {
+        let text = "[project]\nname = \"x\"\nversion = \"0.1.0\"\ndependencies = [\n    \"ggplot2>=3.4\",\n    \"dplyr\",\n]\n";
+        let (updated, removed) = remove_dependency_from_toml_text(text, "ggplot2").unwrap();
+        assert!(removed);
+        assert!(!updated.contains("ggplot2"));
+        assert!(updated.contains("\"dplyr\""));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,8 @@ mod resolver;
 mod version;
 
 use config::{
-    AddDependencyResult, add_dependency, init_config, parse_dep, parse_dep_name, read_config,
+    AddDependencyResult, RemoveDependencyResult, add_dependency, init_config, parse_dep,
+    parse_dep_name, read_config, remove_dependency,
 };
 use index::fetch_cran_index;
 use installer::{build_urls, build_urls_from_pairs, download_and_install};
@@ -44,9 +45,14 @@ enum Commands {
     Sync,
     /// Resolve dependencies from ruv.toml and write ruv.lock
     Lock,
-    /// Add a package to ruv.toml and sync
+    /// Add a package to ruv.toml and re-lock
     Add {
-        /// Name of the package to add
+        /// Name of the package to add (optionally with version constraint, e.g. ggplot2>=3.4)
+        package: String,
+    },
+    /// Remove a package from ruv.toml and re-lock
+    Remove {
+        /// Name of the package to remove
         package: String,
     },
     /// Run a script with the project library
@@ -62,6 +68,36 @@ fn fmt_duration(ms: u128) -> String {
     } else {
         format!("{:.2}s", ms as f64 / 1000.0)
     }
+}
+
+/// Reads ruv.toml, resolves all dependencies, writes ruv.lock, and prints progress.
+/// Exits the process on error.
+fn run_lock(verbose: bool) {
+    let config = read_config().unwrap_or_else(|e| {
+        eprintln!("error: {e}");
+        std::process::exit(1);
+    });
+    let root_deps: Vec<_> = config
+        .project
+        .dependencies
+        .iter()
+        .map(|d| parse_dep(d))
+        .collect();
+    let root_names: Vec<String> = root_deps.iter().map(|d| d.name.clone()).collect();
+
+    let t = Instant::now();
+    let index = fetch_cran_index();
+    let resolved = resolve_all(&root_deps, &index, verbose).unwrap_or_else(|e| {
+        eprintln!("error: {e}");
+        std::process::exit(1);
+    });
+    println!(
+        "Resolved {} packages in {}",
+        resolved.len(),
+        fmt_duration(t.elapsed().as_millis())
+    );
+
+    write_lockfile(&root_names, &resolved, &index);
 }
 
 fn main() {
@@ -122,31 +158,7 @@ fn main() {
         }
 
         Commands::Lock => {
-            let config = read_config().unwrap_or_else(|e| {
-                eprintln!("error: {e}");
-                std::process::exit(1);
-            });
-            let root_deps: Vec<_> = config
-                .project
-                .dependencies
-                .iter()
-                .map(|d| parse_dep(d))
-                .collect();
-            let root_names: Vec<String> = root_deps.iter().map(|d| d.name.clone()).collect();
-
-            let t = Instant::now();
-            let index = fetch_cran_index();
-            let resolved = resolve_all(&root_deps, &index, verbose).unwrap_or_else(|e| {
-                eprintln!("error: {e}");
-                std::process::exit(1);
-            });
-            println!(
-                "Resolved {} packages in {}",
-                resolved.len(),
-                fmt_duration(t.elapsed().as_millis())
-            );
-
-            write_lockfile(&root_names, &resolved, &index);
+            run_lock(verbose);
         }
 
         Commands::Sync => {
@@ -229,11 +241,28 @@ fn main() {
             }) {
                 AddDependencyResult::Added => {
                     println!("added \"{}\" to ruv.toml", package);
-                    println!("next: run `ruv lock && ruv sync`");
+                    run_lock(verbose);
+                    println!("next: run `ruv sync` to install");
                 }
                 AddDependencyResult::AlreadyPresent => {
-                    println!("\"{}\" is already in ruv.toml", package);
-                    println!("next: run `ruv lock && ruv sync`");
+                    println!("\"{}\" is already in ruv.toml — nothing to do", package);
+                }
+            }
+        }
+
+        Commands::Remove { package } => {
+            match remove_dependency(&package).unwrap_or_else(|e| {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }) {
+                RemoveDependencyResult::Removed => {
+                    println!("removed \"{}\" from ruv.toml", package);
+                    run_lock(verbose);
+                    println!("next: run `ruv sync` to apply");
+                }
+                RemoveDependencyResult::NotFound => {
+                    eprintln!("error: \"{}\" is not in ruv.toml", package);
+                    std::process::exit(1);
                 }
             }
         }


### PR DESCRIPTION
## Summary

Closes #15 — `ruv add` / `ruv remove` should properly update the lockfile.

- `ruv add <pkg>` now automatically re-runs `lock` after writing `ruv.toml`, then tells the user to run `ruv sync` to install
- `ruv remove <pkg>` is a new command that removes a package from `ruv.toml` by name (version constraint suffix is ignored) and auto-locks
- Lock logic extracted into a `run_lock()` helper reused by `add`, `remove`, and the explicit `lock` command

## Behaviour

```sh
ruv add ggplot2       # updates ruv.toml + resolves + writes ruv.lock → "next: run ruv sync to install"
ruv remove ggplot2    # updates ruv.toml + resolves + writes ruv.lock → "next: run ruv sync to apply"
ruv lock              # explicit lock unchanged
```

`ruv sync` remains a separate command — it is not run automatically.

## Tests

4 new tests for `remove_dependency_from_toml_text`:
- basic removal
- package not found returns `NotFound`
- last item leaves empty array
- matches by name, ignores version constraint suffix (e.g. removes `ggplot2>=3.4` when given `ggplot2`)

73 tests passing, clippy and fmt clean.