### PR TITLE
feat: ruv migrate renv — migrate renv.lock to ruv.toml

### DIFF
--- a/src/installer.rs
+++ b/src/installer.rs
@@ -115,11 +115,14 @@ fn make_url(
 }
 
 /// Returns (name, version, url) tuples from lockfile (name, version, registry) triples.
+/// `r_version_override` is the R version recorded in the lockfile (e.g. "4.4").
+/// If None (old lockfile format), falls back to the current system R version.
 pub fn build_urls_from_pairs(
     packages: &[(String, String, String)],
+    r_version_override: Option<&str>,
 ) -> Vec<(String, String, String)> {
     let (platform, ext) = get_platform();
-    let r_version = get_r_version();
+    let r_version = r_version_override.unwrap_or_else(|| get_r_version());
     packages
         .iter()
         .map(|(name, version, registry)| {
@@ -141,8 +144,18 @@ pub fn build_urls(
     index: &HashMap<String, Package>,
 ) -> Vec<(String, String, String)> {
     let (platform, ext) = get_platform();
-    let r_version = get_r_version();
+    build_urls_with(packages, index, platform, ext, get_r_version())
+}
 
+/// Testable inner implementation — takes platform/ext/r_version explicitly
+/// so tests can avoid invoking the real R binary.
+fn build_urls_with(
+    packages: &[String],
+    index: &HashMap<String, Package>,
+    platform: &str,
+    ext: &str,
+    r_version: &str,
+) -> Vec<(String, String, String)> {
     packages
         .iter()
         .filter_map(|name| {
@@ -340,7 +353,13 @@ mod tests {
     #[test]
     fn test_build_urls_format() {
         let index = make_index(&[("ggplot2", "3.5.1")]);
-        let urls = build_urls(&["ggplot2".to_string()], &index);
+        let urls = build_urls_with(
+            &["ggplot2".to_string()],
+            &index,
+            "macosx/big-sur-arm64",
+            "tgz",
+            "4.4",
+        );
         assert_eq!(urls.len(), 1);
         let (name, version, url) = &urls[0];
         assert_eq!(name, "ggplot2");
@@ -353,7 +372,13 @@ mod tests {
     #[test]
     fn test_build_urls_drops_missing_packages() {
         let index = make_index(&[("ggplot2", "3.5.1")]);
-        let urls = build_urls(&["ggplot2".to_string(), "not-in-index".to_string()], &index);
+        let urls = build_urls_with(
+            &["ggplot2".to_string(), "not-in-index".to_string()],
+            &index,
+            "macosx/big-sur-arm64",
+            "tgz",
+            "4.4",
+        );
         assert_eq!(urls.len(), 1);
         assert_eq!(urls[0].0, "ggplot2");
     }
@@ -361,7 +386,7 @@ mod tests {
     #[test]
     fn test_build_urls_empty_input() {
         let index = make_index(&[("ggplot2", "3.5.1")]);
-        let urls = build_urls(&[], &index);
+        let urls = build_urls_with(&[], &index, "macosx/big-sur-arm64", "tgz", "4.4");
         assert!(urls.is_empty());
     }
 }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,4 +1,5 @@
 use crate::index::Package;
+use crate::installer::get_r_version;
 use crate::version::RVersion;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -9,12 +10,20 @@ const RSPM_BASE: &str = "https://packagemanager.posit.co/cran";
 /// Write ruv.lock from the pubgrub-resolved map of package → version.
 /// All packages use RSPM/latest as their registry — the exact version in the
 /// filename is the reproducibility guarantee, not the snapshot date.
+/// The R version used at lock time is recorded in [manifest] so sync can use
+/// the same version regardless of what R is on PATH at sync time.
 pub fn write_lockfile(
     roots: &[String],
     resolved: &HashMap<String, RVersion>,
     index: &HashMap<String, Package>,
 ) {
-    write_lockfile_to(Path::new("ruv.lock"), roots, resolved, index);
+    write_lockfile_to(
+        Path::new("ruv.lock"),
+        roots,
+        resolved,
+        index,
+        get_r_version(),
+    );
     println!("wrote ruv.lock");
 }
 
@@ -23,12 +32,14 @@ fn write_lockfile_to(
     roots: &[String],
     resolved: &HashMap<String, RVersion>,
     index: &HashMap<String, Package>,
+    r_version: &str,
 ) {
     let mut sorted_roots = roots.to_vec();
     sorted_roots.sort();
 
     let mut out = String::from("# ruv.lock — generated, do not edit\n\nversion = 1\n\n");
     out.push_str("[manifest]\n");
+    out.push_str(&format!("r_version = \"{}\"\n", r_version));
     out.push_str("dependencies = [");
     out.push_str(
         &sorted_roots
@@ -87,6 +98,14 @@ pub fn read_lockfile() -> Vec<(String, String, String)> {
     let text =
         std::fs::read_to_string("ruv.lock").expect("no ruv.lock found — run `ruv lock` first");
     parse_lockfile(&text)
+}
+
+/// Reads the R version recorded in the [manifest] section of ruv.lock.
+/// Returns None if the lockfile predates r_version recording (older format).
+pub fn read_lockfile_r_version() -> Option<String> {
+    let text = std::fs::read_to_string("ruv.lock").ok()?;
+    let lf: LockfileHeader = toml::from_str(&text).ok()?;
+    lf.manifest.r_version
 }
 
 /// Returns true if the lockfile exists and its manifest deps match the given roots.
@@ -149,6 +168,8 @@ struct LockfileHeader {
 
 #[derive(Deserialize)]
 struct Manifest {
+    #[serde(default)]
+    r_version: Option<String>,
     dependencies: Vec<String>,
 }
 
@@ -187,11 +208,12 @@ mod tests {
         let resolved = make_resolved(&[("ggplot2", "3.5.1"), ("rlang", "1.1.4")]);
         let roots = vec!["ggplot2".to_string()];
 
-        write_lockfile_to(tmp.path(), &roots, &resolved, &index);
+        write_lockfile_to(tmp.path(), &roots, &resolved, &index, "4.4");
 
         let contents = std::fs::read_to_string(tmp.path()).unwrap();
         assert!(contents.contains("version = 1"));
         assert!(contents.contains("[manifest]"));
+        assert!(contents.contains("r_version = \"4.4\""));
         assert!(contents.contains("dependencies = [\"ggplot2\"]"));
         assert!(contents.contains("[[package]]"));
         assert!(contents.contains("name = \"ggplot2\""));
@@ -205,7 +227,7 @@ mod tests {
         let resolved = make_resolved(&[("ggplot2", "3.5.1")]);
         let roots = vec!["ggplot2".to_string()];
 
-        write_lockfile_to(tmp.path(), &roots, &resolved, &index);
+        write_lockfile_to(tmp.path(), &roots, &resolved, &index, "4.4");
 
         let contents = std::fs::read_to_string(tmp.path()).unwrap();
         assert!(
@@ -222,7 +244,7 @@ mod tests {
         let resolved = make_resolved(&[("nlme", "2.23-26")]);
         let roots = vec!["nlme".to_string()];
 
-        write_lockfile_to(tmp.path(), &roots, &resolved, &index);
+        write_lockfile_to(tmp.path(), &roots, &resolved, &index, "4.4");
 
         let contents = std::fs::read_to_string(tmp.path()).unwrap();
         assert!(contents.contains("version = \"2.23-26\""));
@@ -236,12 +258,25 @@ mod tests {
         let resolved = make_resolved(&[("zzz", "1.0"), ("aaa", "2.0")]);
         let roots = vec!["zzz".to_string(), "aaa".to_string()];
 
-        write_lockfile_to(tmp.path(), &roots, &resolved, &index);
+        write_lockfile_to(tmp.path(), &roots, &resolved, &index, "4.4");
 
         let contents = std::fs::read_to_string(tmp.path()).unwrap();
         let aaa_pos = contents.find("\"aaa\"").unwrap();
         let zzz_pos = contents.find("\"zzz\"").unwrap();
         assert!(aaa_pos < zzz_pos);
+    }
+
+    #[test]
+    fn test_write_lockfile_records_r_version() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let index = make_index(&[("ggplot2", "3.5.1")]);
+        let resolved = make_resolved(&[("ggplot2", "3.5.1")]);
+        let roots = vec!["ggplot2".to_string()];
+
+        write_lockfile_to(tmp.path(), &roots, &resolved, &index, "4.4");
+
+        let contents = std::fs::read_to_string(tmp.path()).unwrap();
+        assert!(contents.contains("r_version = \"4.4\""));
     }
 
     #[test]
@@ -251,7 +286,7 @@ mod tests {
         let resolved = make_resolved(&[("ggplot2", "3.5.1"), ("rlang", "1.1.4")]);
         let roots = vec!["ggplot2".to_string()];
 
-        write_lockfile_to(tmp.path(), &roots, &resolved, &index);
+        write_lockfile_to(tmp.path(), &roots, &resolved, &index, "4.4");
 
         let text = std::fs::read_to_string(tmp.path()).unwrap();
         let mut parsed = parse_lockfile(&text);

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use config::{
 };
 use index::fetch_cran_index;
 use installer::{build_urls, build_urls_from_pairs, download_and_install};
-use lockfile::{lockfile_is_fresh, read_lockfile, write_lockfile};
+use lockfile::{lockfile_is_fresh, read_lockfile, read_lockfile_r_version, write_lockfile};
 use resolver::{resolve, resolve_all};
 
 const LIB_DIR: &str = ".ruv/library";
@@ -190,7 +190,14 @@ fn main() {
 
             let t = Instant::now();
             let locked = read_lockfile();
-            let packages = build_urls_from_pairs(&locked);
+            let lock_r_version = read_lockfile_r_version();
+            if lock_r_version.is_none() {
+                eprintln!(
+                    "warning: ruv.lock does not record an R version (old format) — \
+                     using system R for binary URLs. Re-run `ruv lock` to fix."
+                );
+            }
+            let packages = build_urls_from_pairs(&locked, lock_r_version.as_deref());
             println!(
                 "Resolved {} packages in {}",
                 locked.len(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod index;
 mod installer;
 mod lockfile;
 mod r_version;
+mod renv_migrate;
 mod resolver;
 mod version;
 
@@ -49,10 +50,25 @@ enum Commands {
         /// Name of the package to add
         package: String,
     },
+    /// Migrate an existing renv project to ruv
+    Migrate {
+        #[command(subcommand)]
+        source: MigrateSource,
+    },
     /// Run a script with the project library
     Run {
         /// Arguments to pass to Rscript (e.g. analysis.R or -e "library(ggplot2)")
         args: Vec<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum MigrateSource {
+    /// Migrate from an renv.lock file
+    Renv {
+        /// Path to the renv.lock file (defaults to ./renv.lock)
+        #[arg(default_value = "renv.lock")]
+        renv_file: String,
     },
 }
 
@@ -62,6 +78,36 @@ fn fmt_duration(ms: u128) -> String {
     } else {
         format!("{:.2}s", ms as f64 / 1000.0)
     }
+}
+
+/// Reads ruv.toml, resolves all dependencies, writes ruv.lock, and prints progress.
+/// Exits the process on error.
+fn run_lock(verbose: bool) {
+    let config = read_config().unwrap_or_else(|e| {
+        eprintln!("error: {e}");
+        std::process::exit(1);
+    });
+    let root_deps: Vec<_> = config
+        .project
+        .dependencies
+        .iter()
+        .map(|d| parse_dep(d))
+        .collect();
+    let root_names: Vec<String> = root_deps.iter().map(|d| d.name.clone()).collect();
+
+    let t = Instant::now();
+    let index = fetch_cran_index();
+    let resolved = resolve_all(&root_deps, &index, verbose).unwrap_or_else(|e| {
+        eprintln!("error: {e}");
+        std::process::exit(1);
+    });
+    println!(
+        "Resolved {} packages in {}",
+        resolved.len(),
+        fmt_duration(t.elapsed().as_millis())
+    );
+
+    write_lockfile(&root_names, &resolved, &index);
 }
 
 fn main() {
@@ -122,31 +168,7 @@ fn main() {
         }
 
         Commands::Lock => {
-            let config = read_config().unwrap_or_else(|e| {
-                eprintln!("error: {e}");
-                std::process::exit(1);
-            });
-            let root_deps: Vec<_> = config
-                .project
-                .dependencies
-                .iter()
-                .map(|d| parse_dep(d))
-                .collect();
-            let root_names: Vec<String> = root_deps.iter().map(|d| d.name.clone()).collect();
-
-            let t = Instant::now();
-            let index = fetch_cran_index();
-            let resolved = resolve_all(&root_deps, &index, verbose).unwrap_or_else(|e| {
-                eprintln!("error: {e}");
-                std::process::exit(1);
-            });
-            println!(
-                "Resolved {} packages in {}",
-                resolved.len(),
-                fmt_duration(t.elapsed().as_millis())
-            );
-
-            write_lockfile(&root_names, &resolved, &index);
+            run_lock(verbose);
         }
 
         Commands::Sync => {
@@ -236,6 +258,49 @@ fn main() {
                     println!("next: run `ruv lock && ruv sync`");
                 }
             }
+        }
+
+        Commands::Migrate {
+            source: MigrateSource::Renv { renv_file },
+        } => {
+            let renv_path = std::path::Path::new(&renv_file);
+            let result = renv_migrate::parse_renv_lock(renv_path).unwrap_or_else(|e| {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            });
+
+            let project_name = std::env::current_dir()
+                .ok()
+                .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "my-project".to_string());
+
+            println!(
+                "Migrating {} packages from {} (R {})...",
+                result.packages.len(),
+                renv_file,
+                result.r_version
+            );
+
+            if !result.skipped.is_empty() {
+                eprintln!(
+                    "warning: {} package(s) could not be migrated automatically:",
+                    result.skipped.len()
+                );
+                for (pkg, reason) in &result.skipped {
+                    eprintln!("  {} — {}", pkg, reason);
+                }
+            }
+
+            renv_migrate::write_ruv_toml(&project_name, &result).unwrap_or_else(|e| {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            });
+            println!("wrote ruv.toml");
+
+            // Run lock to validate the migrated dependencies resolve correctly
+            run_lock(verbose);
+            println!("next: run `ruv sync` to install the project library");
         }
 
         Commands::Run { args } => {

--- a/src/renv_migrate.rs
+++ b/src/renv_migrate.rs
@@ -1,0 +1,308 @@
+/// Parser and ruv.toml writer for `renv.lock` migration.
+///
+/// renv.lock is a JSON file with the structure:
+/// ```json
+/// {
+///   "R": { "Version": "4.4.0", "Repositories": [{"Name": "CRAN", "URL": "..."}] },
+///   "Packages": {
+///     "ggplot2": { "Package": "ggplot2", "Source": "Repository", "Repository": "CRAN", ... },
+///     ...
+///   }
+/// }
+/// ```
+///
+/// We extract:
+/// - R version (major.minor only, per ruv convention)
+/// - Repository aliases + URLs
+/// - Package names where Source == "Repository" (CRAN-like)
+///
+/// GitHub/local/other sources are skipped with a warning — they require
+/// additional ruv config not expressible in a plain migration.
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+const CONFIG_FILE: &str = "ruv.toml";
+
+#[derive(Deserialize)]
+struct RenvLock {
+    #[serde(rename = "R")]
+    r: RenvR,
+    #[serde(rename = "Packages", default)]
+    packages: HashMap<String, RenvPackage>,
+}
+
+#[derive(Deserialize)]
+struct RenvR {
+    #[serde(rename = "Version")]
+    version: String,
+    #[serde(rename = "Repositories", default)]
+    repositories: Vec<RenvRepository>,
+}
+
+#[derive(Deserialize)]
+struct RenvRepository {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "URL")]
+    url: String,
+}
+
+#[derive(Deserialize)]
+struct RenvPackage {
+    #[serde(rename = "Package")]
+    package: String,
+    #[serde(rename = "Source", default)]
+    source: String,
+}
+
+/// The result of parsing an renv.lock.
+#[derive(Debug)]
+pub struct MigrateResult {
+    /// R major.minor version string, e.g. "4.4"
+    pub r_version: String,
+    /// Repositories as (alias, url) pairs, in order
+    pub repositories: Vec<(String, String)>,
+    /// Package names successfully migrated (Source == "Repository")
+    pub packages: Vec<String>,
+    /// Package names skipped (non-CRAN source), with reason
+    pub skipped: Vec<(String, String)>,
+}
+
+/// Parse `renv.lock` at `path` into a `MigrateResult`.
+pub fn parse_renv_lock(path: &Path) -> Result<MigrateResult, String> {
+    let text = std::fs::read_to_string(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            format!(
+                "could not find {} — run this command from a directory containing renv.lock",
+                path.display()
+            )
+        } else {
+            format!("failed to read {}: {}", path.display(), e)
+        }
+    })?;
+
+    let lock: RenvLock = serde_json::from_str(&text)
+        .map_err(|e| format!("failed to parse {}: {}", path.display(), e))?;
+
+    // Truncate R version to major.minor
+    let r_version = lock
+        .r
+        .version
+        .splitn(3, '.')
+        .take(2)
+        .collect::<Vec<_>>()
+        .join(".");
+
+    let repositories: Vec<(String, String)> = lock
+        .r
+        .repositories
+        .into_iter()
+        .map(|r| (r.name, r.url))
+        .collect();
+
+    let mut packages = Vec::new();
+    let mut skipped = Vec::new();
+
+    let mut sorted_pkgs: Vec<RenvPackage> = lock.packages.into_values().collect();
+    sorted_pkgs.sort_by(|a, b| a.package.cmp(&b.package));
+
+    for pkg in sorted_pkgs {
+        match pkg.source.as_str() {
+            "Repository" | "" => packages.push(pkg.package),
+            "GitHub" => skipped.push((
+                pkg.package,
+                "GitHub source — add manually as a GitHub dependency once ruv supports it"
+                    .to_string(),
+            )),
+            other => skipped.push((
+                pkg.package,
+                format!("unsupported source '{}' — add manually", other),
+            )),
+        }
+    }
+
+    Ok(MigrateResult {
+        r_version,
+        repositories,
+        packages,
+        skipped,
+    })
+}
+
+/// Write a `ruv.toml` from a `MigrateResult`.
+/// Errors if `ruv.toml` already exists in the current directory.
+pub fn write_ruv_toml(project_name: &str, result: &MigrateResult) -> Result<(), String> {
+    write_ruv_toml_to(Path::new(CONFIG_FILE), project_name, result)
+}
+
+pub fn write_ruv_toml_to(
+    path: &Path,
+    project_name: &str,
+    result: &MigrateResult,
+) -> Result<(), String> {
+    if path.exists() {
+        return Err(format!(
+            "{} already exists — remove it first or run from a clean directory",
+            path.display()
+        ));
+    }
+
+    let mut out = format!(
+        "# migrated from renv.lock by ruv migrate renv\n\
+         [project]\n\
+         name = \"{}\"\n\
+         version = \"0.1.0\"\n\
+         r-version = \"{}\"\n",
+        project_name, result.r_version
+    );
+
+    if !result.repositories.is_empty() {
+        out.push_str("\nrepositories = [\n");
+        for (alias, url) in &result.repositories {
+            out.push_str(&format!(
+                "    {{ alias = \"{}\", url = \"{}\" }},\n",
+                alias, url
+            ));
+        }
+        out.push_str("]\n");
+    }
+
+    out.push_str("\ndependencies = [\n");
+    for pkg in &result.packages {
+        out.push_str(&format!("    \"{}\",\n", pkg));
+    }
+    out.push_str("]\n");
+
+    std::fs::write(path, out).map_err(|e| format!("failed to write {}: {}", path.display(), e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_temp_lock(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    const SAMPLE_LOCK: &str = r#"{
+  "R": {
+    "Version": "4.4.0",
+    "Repositories": [
+      { "Name": "CRAN", "URL": "https://cloud.r-project.org" }
+    ]
+  },
+  "Packages": {
+    "ggplot2": {
+      "Package": "ggplot2",
+      "Version": "3.5.1",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    },
+    "dplyr": {
+      "Package": "dplyr",
+      "Version": "1.1.4",
+      "Source": "Repository",
+      "Repository": "CRAN"
+    }
+  }
+}"#;
+
+    #[test]
+    fn test_parse_r_version_truncated_to_major_minor() {
+        let f = write_temp_lock(SAMPLE_LOCK);
+        let result = parse_renv_lock(f.path()).unwrap();
+        assert_eq!(result.r_version, "4.4");
+    }
+
+    #[test]
+    fn test_parse_repositories() {
+        let f = write_temp_lock(SAMPLE_LOCK);
+        let result = parse_renv_lock(f.path()).unwrap();
+        assert_eq!(result.repositories.len(), 1);
+        assert_eq!(result.repositories[0].0, "CRAN");
+        assert_eq!(result.repositories[0].1, "https://cloud.r-project.org");
+    }
+
+    #[test]
+    fn test_parse_packages_sorted() {
+        let f = write_temp_lock(SAMPLE_LOCK);
+        let result = parse_renv_lock(f.path()).unwrap();
+        assert_eq!(result.packages, vec!["dplyr", "ggplot2"]);
+        assert!(result.skipped.is_empty());
+    }
+
+    #[test]
+    fn test_parse_skips_github_source() {
+        let lock = r#"{
+  "R": { "Version": "4.4.0", "Repositories": [] },
+  "Packages": {
+    "mypkg": { "Package": "mypkg", "Version": "0.1.0", "Source": "GitHub" }
+  }
+}"#;
+        let f = write_temp_lock(lock);
+        let result = parse_renv_lock(f.path()).unwrap();
+        assert!(result.packages.is_empty());
+        assert_eq!(result.skipped.len(), 1);
+        assert_eq!(result.skipped[0].0, "mypkg");
+        assert!(result.skipped[0].1.contains("GitHub"));
+    }
+
+    #[test]
+    fn test_parse_skips_unknown_source() {
+        let lock = r#"{
+  "R": { "Version": "4.3.1", "Repositories": [] },
+  "Packages": {
+    "localpkg": { "Package": "localpkg", "Version": "0.1.0", "Source": "Local" }
+  }
+}"#;
+        let f = write_temp_lock(lock);
+        let result = parse_renv_lock(f.path()).unwrap();
+        assert!(result.packages.is_empty());
+        assert_eq!(result.skipped[0].0, "localpkg");
+    }
+
+    #[test]
+    fn test_parse_missing_file_gives_clear_error() {
+        let err = parse_renv_lock(Path::new("/nonexistent/renv.lock")).unwrap_err();
+        assert!(err.contains("could not find"), "got: {}", err);
+    }
+
+    #[test]
+    fn test_write_ruv_toml_content() {
+        let result = MigrateResult {
+            r_version: "4.4".to_string(),
+            repositories: vec![(
+                "CRAN".to_string(),
+                "https://cloud.r-project.org".to_string(),
+            )],
+            packages: vec!["dplyr".to_string(), "ggplot2".to_string()],
+            skipped: vec![],
+        };
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        // write_ruv_toml_to errors if file exists, so remove it first
+        let path = tmp.path().with_extension("ruv.toml");
+        write_ruv_toml_to(&path, "my-project", &result).unwrap();
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(contents.contains("r-version = \"4.4\""));
+        assert!(contents.contains("alias = \"CRAN\""));
+        assert!(contents.contains("\"dplyr\""));
+        assert!(contents.contains("\"ggplot2\""));
+    }
+
+    #[test]
+    fn test_write_ruv_toml_errors_if_exists() {
+        let result = MigrateResult {
+            r_version: "4.4".to_string(),
+            repositories: vec![],
+            packages: vec![],
+            skipped: vec![],
+        };
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let err = write_ruv_toml_to(tmp.path(), "proj", &result).unwrap_err();
+        assert!(err.contains("already exists"), "got: {}", err);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #17, closes #42.

Adds `ruv migrate renv` to convert an existing renv project to ruv.

## Usage

```sh
ruv migrate renv              # reads ./renv.lock
ruv migrate renv path/to/renv.lock
```

## What it does

1. Parses `renv.lock` JSON — extracts R version (major.minor), repositories, and package names
2. Skips GitHub/local/other sources with a clear warning per package
3. Writes `ruv.toml` with `r-version`, `repositories`, and `dependencies`
4. Immediately runs `ruv lock` to validate everything resolves — version conflicts surface through the normal PubGrub resolver rather than needing special migration logic
5. Tells the user to run `ruv sync` to install

## Example output

```
Migrating 12 packages from renv.lock (R 4.4)...
warning: 1 package(s) could not be migrated automatically:
  mypkg — GitHub source — add manually as a GitHub dependency once ruv supports it
wrote ruv.toml
Resolved 47 packages in 1.23s
wrote ruv.lock
next: run `ruv sync` to install the project library
```

## Design decision

Version pinning is deliberately not carried over. The renv.lock records exact installed versions, but ruv resolves the best compatible versions from CRAN. If a pinned version is no longer on CRAN latest, the resolver will find the current version — the user can review the `ruv lock` output to see if anything changed significantly. This keeps the migrator simple and avoids needing to implement archive URL fallbacks at this stage.

## Tests

8 tests in `renv_migrate.rs` covering: R version truncation, repository parsing, package sorting, GitHub skip, unknown source skip, missing file error, toml content, and exists-guard.

77 tests passing, clippy and fmt clean.