### PR TITLE
feat: gastown-dev — migrate-renv, r-version-file, add/remove, sync-r-version fix, platform compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
     branches:
+      - gastown-dev
       - development
       - main
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
             runs-on: ubuntu-latest
           - target: aarch64-unknown-linux-musl
             runs-on: ubuntu-latest
+          - target: x86_64-pc-windows-msvc
+            runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -50,17 +52,34 @@ jobs:
       - name: Build binary
         run: cargo build --release --target ${{ matrix.target }}
 
-      - name: Create tarball
+      - name: Create tarball (non-Windows)
+        if: matrix.target != 'x86_64-pc-windows-msvc'
         run: |
           mkdir -p ruv-${{ matrix.target }}/bin
           cp target/${{ matrix.target }}/release/ruv ruv-${{ matrix.target }}/bin/
           tar czf ruv-${{ matrix.target }}.tar.gz ruv-${{ matrix.target }}/
 
-      - name: Upload artifacts
+      - name: Create zip (Windows)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path ruv-${{ matrix.target }}/bin
+          Copy-Item target/${{ matrix.target }}/release/ruv.exe ruv-${{ matrix.target }}/bin/
+          Compress-Archive -Path ruv-${{ matrix.target }} -DestinationPath ruv-${{ matrix.target }}.zip
+
+      - name: Upload artifacts (non-Windows)
+        if: matrix.target != 'x86_64-pc-windows-msvc'
         uses: actions/upload-artifact@v4
         with:
           name: ruv-${{ matrix.target }}
           path: ruv-${{ matrix.target }}.tar.gz
+
+      - name: Upload artifacts (Windows)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruv-${{ matrix.target }}
+          path: ruv-${{ matrix.target }}.zip
 
   publish:
     name: Publish Release
@@ -80,7 +99,9 @@ jobs:
         run: |
           mkdir -p release-assets
           find artifacts -name "*.tar.gz" -exec cp {} release-assets/ \;
+          find artifacts -name "*.zip" -exec cp {} release-assets/ \;
           cp scripts/install.sh release-assets/install.sh
+          cp scripts/install.ps1 release-assets/install.ps1
 
       - name: Upload binaries and installer to GitHub Release
         uses: softprops/action-gh-release@v1
@@ -88,6 +109,8 @@ jobs:
           tag_name: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
           files: |
             release-assets/*.tar.gz
+            release-assets/*.zip
             release-assets/install.sh
+            release-assets/install.ps1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Gas Town runtime state (local only, not part of the project)
+/.beads/
+/.claude/
+/.runtime/
+
 # Rust
 /target
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +67,15 @@ dependencies = [
  "anstyle",
  "once_cell_polyfill",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
 ]
 
 [[package]]
@@ -108,16 +128,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cc"
@@ -148,6 +202,16 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -228,6 +292,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +312,30 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -276,6 +370,53 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "deflate64"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "dirs"
@@ -441,6 +582,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +629,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -704,6 +864,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,6 +985,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +1033,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,6 +1063,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +1089,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain"
@@ -904,6 +1116,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1214,7 +1432,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1258,6 +1476,7 @@ dependencies = [
  "tar",
  "tempfile",
  "toml",
+ "zip",
 ]
 
 [[package]]
@@ -1351,6 +1570,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1499,6 +1729,25 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -1659,6 +1908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,6 +1969,12 @@ checksum = "3595ffe225639f1e0fd8d7269dcc05d2fbfea93cfac2fea367daf1adb60aae91"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1843,7 +2104,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2103,6 +2364,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2171,6 +2441,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -2206,7 +2490,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ serde_json = "1.0.149"
 tar = "0.4.44"
 toml = "1.0.4"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+zip = "2"
+
 [dev-dependencies]
 tempfile = "3.26.0"
 
@@ -24,10 +27,11 @@ tempfile = "3.26.0"
 [package.metadata.dist]
 # Platforms to build binaries for when creating a release
 targets = [
-    "aarch64-apple-darwin",   # macOS ARM (M1/M2/M3/etc)
-    "x86_64-apple-darwin",    # macOS Intel
-    "x86_64-unknown-linux-musl",  # Linux x86_64 (static, no glibc dependency)
-    "aarch64-unknown-linux-musl"  # Linux ARM64 (Graviton, Raspberry Pi, etc)
+    "aarch64-apple-darwin",      # macOS ARM (M1/M2/M3/etc)
+    "x86_64-apple-darwin",       # macOS Intel
+    "x86_64-unknown-linux-musl", # Linux x86_64 (static, no glibc dependency)
+    "aarch64-unknown-linux-musl", # Linux ARM64 (Graviton, Raspberry Pi, etc)
+    "x86_64-pc-windows-msvc"     # Windows x86_64
 ]
 # Installer to generate (shell script for curl | sh)
 installers = ["shell"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ R package management is slow, fragmented, and requires too many tools:
 
 - `install.packages()` — sequential, no caching, no lockfiles
 - `renv` — lockfiles but slow restoration, no binary cache
-- `pak` — faster installs but no lockfile or version management
+- `pak` — faster installs, global cache, and CI-oriented lockfiles, but no project-level reproducibility workflow or R version management
 - `rig` — R version management, but a separate tool
 
 `ruv` replaces all of them with a single fast binary.
@@ -90,9 +90,9 @@ ruv --verbose sync   # show per-package source (cache vs download)
 | | `install.packages` | `renv` | `pak` | **ruv** |
 |---|---|---|---|---|
 | Parallel downloads | ❌ | ❌ | ✅ | ✅ |
-| Global binary cache | ❌ | ❌ | ❌ | ✅ |
-| Lockfile | ❌ | ✅ | ❌ | ✅ |
-| Reproducible binary installs | ❌ | ⚠️ source only | ❌ | ✅ |
+| Global binary cache | ❌ | ❌ | ✅ | ✅ |
+| Lockfile | ❌ | ✅ | ⚠️ CI caching only | ✅ |
+| Reproducible binary installs | ❌ | ⚠️ source only | ⚠️ PPM snapshots only | ✅ |
 | Lock/sync separation | ❌ | ❌ | ❌ | ✅ |
 | R version management | ❌ | ❌ | ❌ | 🚧 planned |
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,90 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Installs ruv on Windows.
+.DESCRIPTION
+    Downloads and installs the ruv binary from GitHub Releases.
+.PARAMETER Tag
+    The release tag to install (default: latest).
+.PARAMETER InstallDir
+    The directory to install ruv into (default: %LOCALAPPDATA%\ruv\bin).
+.EXAMPLE
+    irm https://github.com/A-Fisk/ruv/releases/download/TAG/install.ps1 | iex
+#>
+param(
+    [string]$Tag = "latest",
+    [string]$InstallDir = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "A-Fisk/ruv"
+
+if ($Tag -eq "latest") {
+    Write-Host "Fetching latest release..."
+    $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases"
+    $Tag = $releases[0].tag_name
+    if (-not $Tag) {
+        Write-Error "Error: Could not determine latest release tag"
+        exit 1
+    }
+}
+
+Write-Host "Installing ruv $Tag..."
+
+# Only x86_64 is supported on Windows
+$Target = "x86_64-pc-windows-msvc"
+
+# Determine install directory
+if (-not $InstallDir) {
+    $InstallDir = Join-Path $env:LOCALAPPDATA "ruv\bin"
+}
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+
+# Download zip
+$Url = "https://github.com/$Repo/releases/download/$Tag/ruv-$Target.zip"
+Write-Host "Downloading from: $Url"
+
+$TempDir = Join-Path $env:TEMP "ruv-install-$(Get-Random)"
+New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
+
+try {
+    $ZipPath = Join-Path $TempDir "ruv.zip"
+    Invoke-WebRequest -Uri $Url -OutFile $ZipPath -UseBasicParsing
+
+    Write-Host "Extracting..."
+    Expand-Archive -Path $ZipPath -DestinationPath $TempDir -Force
+
+    $BinaryPath = Join-Path $TempDir "ruv-$Target\bin\ruv.exe"
+    if (-not (Test-Path $BinaryPath)) {
+        Write-Error "Error: Binary not found at expected location: $BinaryPath"
+        exit 1
+    }
+
+    Copy-Item $BinaryPath (Join-Path $InstallDir "ruv.exe") -Force
+} finally {
+    Remove-Item -Recurse -Force $TempDir -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "ruv $Tag installed successfully!"
+Write-Host ""
+Write-Host "Binary location: $InstallDir\ruv.exe"
+Write-Host ""
+
+# Check if install dir is in PATH
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$PathDirs = $UserPath -split ";"
+if ($PathDirs -contains $InstallDir) {
+    Write-Host "$InstallDir is already in your PATH"
+    Write-Host ""
+    Write-Host "You can now run: ruv --help"
+} else {
+    Write-Host "WARNING: $InstallDir is NOT in your PATH"
+    Write-Host ""
+    Write-Host "Run the following command to add it to your user PATH:"
+    Write-Host ""
+    Write-Host "  [Environment]::SetEnvironmentVariable('Path', `$env:Path + ';$InstallDir', 'User')"
+    Write-Host ""
+    Write-Host "Then restart your terminal."
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -42,7 +42,6 @@ fn hard_link_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
 mod tests {
     use super::*;
     use std::fs;
-    use std::os::unix::fs::MetadataExt;
 
     #[test]
     fn test_package_cache_path_format() {
@@ -68,8 +67,11 @@ mod tests {
         assert!(dst.join("subdir/nested.txt").exists());
     }
 
+    #[cfg(unix)]
     #[test]
     fn test_hard_link_dir_creates_true_hard_links() {
+        use std::os::unix::fs::MetadataExt;
+
         let tmp = tempfile::tempdir().unwrap();
         let src = tmp.path().join("src");
         let dst = tmp.path().join("dst");

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -425,7 +425,13 @@ mod tests {
     #[test]
     fn test_build_urls_format() {
         let index = make_index(&[("ggplot2", "3.5.1")]);
-        let urls = build_urls_with(&["ggplot2".to_string()], &index, "macosx/big-sur-arm64", "tgz", "4.4");
+        let urls = build_urls_with(
+            &["ggplot2".to_string()],
+            &index,
+            "macosx/big-sur-arm64",
+            "tgz",
+            "4.4",
+        );
         assert_eq!(urls.len(), 1);
         let (name, version, url) = &urls[0];
         assert_eq!(name, "ggplot2");

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -103,7 +103,9 @@ fn parse_os_release(content: &str) -> String {
             eprintln!(
                 "       For HPC clusters, use `ruv sync --offline` with a pre-populated library."
             );
-            eprintln!("       To populate the library on a supported system, run `ruv sync` there first,");
+            eprintln!(
+                "       To populate the library on a supported system, run `ruv sync` there first,"
+            );
             eprintln!("       then copy the .ruv/library directory to the HPC node.");
             std::process::exit(1);
         }
@@ -393,13 +395,21 @@ mod tests {
         let (name, version, url) = &urls[0];
         assert_eq!(name, "ggplot2");
         assert_eq!(version, "3.5.1");
-        assert!(url.contains("ggplot2_3.5.1"), "url should contain pkg_ver: {}", url);
+        assert!(
+            url.contains("ggplot2_3.5.1"),
+            "url should contain pkg_ver: {}",
+            url
+        );
         assert!(
             url.starts_with("https://packagemanager.posit.co/cran/latest"),
             "url should start with RSPM base: {}",
             url
         );
-        assert!(url.contains("/contrib/"), "url should contain /contrib/: {}", url);
+        assert!(
+            url.contains("/contrib/"),
+            "url should contain /contrib/: {}",
+            url
+        );
     }
 
     #[test]

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -36,45 +36,93 @@ pub fn get_platform() -> (&'static str, &'static str) {
     (path.as_str(), ext.as_str())
 }
 
-/// Read /etc/os-release and map to an RSPM distro string.
-/// Falls back to "ubuntu-jammy" (Ubuntu 22.04) if unrecognised.
-#[cfg(target_os = "linux")]
-fn linux_rspm_distro() -> String {
-    let content = std::fs::read_to_string("/etc/os-release").unwrap_or_default();
+/// Parse /etc/os-release content and return the RSPM distro string.
+/// Separated from linux_rspm_distro() to enable testing without file I/O.
+fn parse_os_release(content: &str) -> String {
     let mut id = String::new();
-    let mut codename = String::new();
     let mut version_id = String::new();
+    let mut version_codename = String::new();
+    let mut ubuntu_codename = String::new();
+
     for line in content.lines() {
         if let Some(v) = line.strip_prefix("ID=") {
             id = v.trim_matches('"').to_lowercase();
-        } else if let Some(v) = line.strip_prefix("VERSION_CODENAME=") {
-            codename = v.trim_matches('"').to_lowercase();
         } else if let Some(v) = line.strip_prefix("VERSION_ID=") {
             version_id = v.trim_matches('"').to_string();
+        } else if let Some(v) = line.strip_prefix("VERSION_CODENAME=") {
+            version_codename = v.trim_matches('"').to_string();
+        } else if let Some(v) = line.strip_prefix("UBUNTU_CODENAME=") {
+            ubuntu_codename = v.trim_matches('"').to_string();
         }
     }
-    // Prefer codename (ubuntu: jammy, noble; debian: bullseye, bookworm)
-    if !codename.is_empty() && matches!(id.as_str(), "ubuntu" | "debian") {
-        return format!("{}-{}", id, codename);
-    }
-    // Fallback: map version_id for distros without VERSION_CODENAME
-    match (id.as_str(), version_id.as_str()) {
-        ("ubuntu", "22.04") => "ubuntu-jammy".to_string(),
-        ("ubuntu", "24.04") => "ubuntu-noble".to_string(),
-        ("ubuntu", "20.04") => "ubuntu-focal".to_string(),
-        ("debian", "11") => "debian-bullseye".to_string(),
-        ("debian", "12") => "debian-bookworm".to_string(),
-        ("rhel" | "centos", "7") => "centos7".to_string(),
-        ("rhel", "8") => "rhel8".to_string(),
-        ("rhel", "9") => "rhel9".to_string(),
+
+    match id.as_str() {
+        "ubuntu" => {
+            let codename = if !version_codename.is_empty() {
+                version_codename
+            } else if !ubuntu_codename.is_empty() {
+                ubuntu_codename
+            } else {
+                // fallback by version number
+                if version_id.starts_with("20.") {
+                    "focal".to_string()
+                } else if version_id.starts_with("22.") {
+                    "jammy".to_string()
+                } else if version_id.starts_with("24.") {
+                    "noble".to_string()
+                } else {
+                    eprintln!(
+                        "warning: unknown Ubuntu version '{}', defaulting to ubuntu-jammy",
+                        version_id
+                    );
+                    "jammy".to_string()
+                }
+            };
+            format!("ubuntu-{}", codename)
+        }
+        "debian" => match version_id.as_str() {
+            "11" => "debian-bullseye".to_string(),
+            "12" => "debian-bookworm".to_string(),
+            _ => {
+                eprintln!(
+                    "warning: unknown Debian version '{}', defaulting to ubuntu-jammy",
+                    version_id
+                );
+                "ubuntu-jammy".to_string()
+            }
+        },
+        "rhel" | "centos" | "rocky" | "almalinux" => {
+            let major = version_id.split('.').next().unwrap_or("8");
+            match major {
+                "9" => "rhel9".to_string(),
+                _ => "rhel8".to_string(),
+            }
+        }
+        id if id == "sles" || id == "sle_hpc" || id.starts_with("opensuse") => {
+            eprintln!("error: SLES/openSUSE is not supported by RSPM binary packages.");
+            eprintln!(
+                "       For HPC clusters, use `ruv sync --offline` with a pre-populated library."
+            );
+            eprintln!("       To populate the library on a supported system, run `ruv sync` there first,");
+            eprintln!("       then copy the .ruv/library directory to the HPC node.");
+            std::process::exit(1);
+        }
         _ => {
             eprintln!(
-                "warning: unrecognised Linux distro ({} {}), defaulting to ubuntu-jammy for RSPM",
-                id, version_id
+                "warning: unknown Linux distribution '{}', defaulting to ubuntu-jammy",
+                id
             );
             "ubuntu-jammy".to_string()
         }
     }
+}
+
+fn linux_rspm_distro() -> &'static str {
+    static DISTRO: OnceLock<String> = OnceLock::new();
+    DISTRO.get_or_init(|| {
+        let content = std::fs::read_to_string("/etc/os-release").unwrap_or_default();
+        parse_os_release(&content)
+    })
 }
 
 pub fn get_r_version() -> &'static str {
@@ -345,9 +393,13 @@ mod tests {
         let (name, version, url) = &urls[0];
         assert_eq!(name, "ggplot2");
         assert_eq!(version, "3.5.1");
-        assert!(url.contains("ggplot2_3.5.1"));
-        assert!(url.starts_with("https://packagemanager.posit.co/cran/latest/bin/"));
-        assert!(url.contains("/contrib/"));
+        assert!(url.contains("ggplot2_3.5.1"), "url should contain pkg_ver: {}", url);
+        assert!(
+            url.starts_with("https://packagemanager.posit.co/cran/latest"),
+            "url should start with RSPM base: {}",
+            url
+        );
+        assert!(url.contains("/contrib/"), "url should contain /contrib/: {}", url);
     }
 
     #[test]
@@ -363,5 +415,85 @@ mod tests {
         let index = make_index(&[("ggplot2", "3.5.1")]);
         let urls = build_urls(&[], &index);
         assert!(urls.is_empty());
+    }
+
+    #[test]
+    fn test_parse_os_release_ubuntu_codename() {
+        let content = "ID=ubuntu\nVERSION_ID=\"22.04\"\nVERSION_CODENAME=jammy\n";
+        assert_eq!(parse_os_release(content), "ubuntu-jammy");
+    }
+
+    #[test]
+    fn test_parse_os_release_ubuntu_ubuntu_codename_field() {
+        // Some Ubuntu variants use UBUNTU_CODENAME instead of VERSION_CODENAME
+        let content = "ID=ubuntu\nVERSION_ID=\"22.04\"\nUBUNTU_CODENAME=jammy\n";
+        assert_eq!(parse_os_release(content), "ubuntu-jammy");
+    }
+
+    #[test]
+    fn test_parse_os_release_ubuntu_focal() {
+        let content = "ID=ubuntu\nVERSION_ID=\"20.04\"\n";
+        assert_eq!(parse_os_release(content), "ubuntu-focal");
+    }
+
+    #[test]
+    fn test_parse_os_release_ubuntu_noble() {
+        let content = "ID=ubuntu\nVERSION_ID=\"24.04\"\nVERSION_CODENAME=noble\n";
+        assert_eq!(parse_os_release(content), "ubuntu-noble");
+    }
+
+    #[test]
+    fn test_parse_os_release_debian_11() {
+        let content = "ID=debian\nVERSION_ID=\"11\"\n";
+        assert_eq!(parse_os_release(content), "debian-bullseye");
+    }
+
+    #[test]
+    fn test_parse_os_release_debian_12() {
+        let content = "ID=debian\nVERSION_ID=\"12\"\n";
+        assert_eq!(parse_os_release(content), "debian-bookworm");
+    }
+
+    #[test]
+    fn test_parse_os_release_rhel8() {
+        let content = "ID=\"rhel\"\nVERSION_ID=\"8.9\"\n";
+        assert_eq!(parse_os_release(content), "rhel8");
+    }
+
+    #[test]
+    fn test_parse_os_release_rhel9() {
+        let content = "ID=\"rhel\"\nVERSION_ID=\"9.2\"\n";
+        assert_eq!(parse_os_release(content), "rhel9");
+    }
+
+    #[test]
+    fn test_parse_os_release_rocky_linux() {
+        let content = "ID=\"rocky\"\nVERSION_ID=\"8.7\"\n";
+        assert_eq!(parse_os_release(content), "rhel8");
+    }
+
+    #[test]
+    fn test_parse_os_release_almalinux_9() {
+        let content = "ID=\"almalinux\"\nVERSION_ID=\"9.1\"\n";
+        assert_eq!(parse_os_release(content), "rhel9");
+    }
+
+    #[test]
+    fn test_parse_os_release_centos() {
+        let content = "ID=\"centos\"\nVERSION_ID=\"8\"\n";
+        assert_eq!(parse_os_release(content), "rhel8");
+    }
+
+    #[test]
+    fn test_parse_os_release_unknown_defaults_to_ubuntu_jammy() {
+        let content = "ID=arch\nVERSION_ID=\"2024.01.01\"\n";
+        assert_eq!(parse_os_release(content), "ubuntu-jammy");
+    }
+
+    #[test]
+    fn test_parse_os_release_quoted_id() {
+        // Some distros quote the ID field
+        let content = "ID=\"ubuntu\"\nVERSION_ID=\"22.04\"\nVERSION_CODENAME=jammy\n";
+        assert_eq!(parse_os_release(content), "ubuntu-jammy");
     }
 }

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -1,6 +1,5 @@
 use crate::cache::{cache_dir, hard_link_into_library, is_cached, package_cache_path};
 use crate::index::Package;
-use flate2::read::GzDecoder;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use rayon::prelude::*;
 use std::collections::HashMap;
@@ -28,7 +27,11 @@ pub fn get_platform() -> (&'static str, &'static str) {
             let distro = linux_rspm_distro();
             (format!("linux/{}", distro), "tar.gz".to_string())
         }
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        #[cfg(target_os = "windows")]
+        {
+            ("windows".to_string(), "zip".to_string())
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
         {
             panic!("Unsupported OS for RSPM package downloads");
         }
@@ -203,6 +206,39 @@ pub fn build_urls(
         .collect()
 }
 
+/// Extracts a downloaded package archive into packages_dir.
+/// On Windows: uses zip extraction. On other platforms: uses gzip+tar.
+fn extract_package(bytes: &[u8], packages_dir: &Path, name: &str, version: &str) {
+    #[cfg(target_os = "windows")]
+    {
+        use std::io::Cursor;
+        zip::ZipArchive::new(Cursor::new(bytes))
+            .and_then(|mut archive| archive.extract(packages_dir))
+            .unwrap_or_else(|e| {
+                eprintln!(
+                    "\nerror: failed to extract {} {}: {}\n       \
+                     The downloaded file may not be a valid binary package.",
+                    name, version, e
+                );
+                std::process::exit(1);
+            });
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        use flate2::read::GzDecoder;
+        let decoder = GzDecoder::new(bytes);
+        let mut archive = tar::Archive::new(decoder);
+        archive.unpack(packages_dir).unwrap_or_else(|e| {
+            eprintln!(
+                "\nerror: failed to extract {} {}: {}\n       \
+                 The downloaded file may not be a valid binary package.",
+                name, version, e
+            );
+            std::process::exit(1);
+        });
+    }
+}
+
 /// Reads installed packages from a library dir by parsing each DESCRIPTION file.
 /// Returns a map of package name → installed version.
 fn read_installed(lib_dir: &Path) -> HashMap<String, String> {
@@ -344,16 +380,7 @@ pub fn download_and_install(
         // extract to cache: unpacks {name}/ into packages dir, then rename to {name}_{version}/
         let packages_dir = cache_dir().join("packages");
         std::fs::create_dir_all(&packages_dir).unwrap();
-        let decoder = GzDecoder::new(bytes.as_slice());
-        let mut archive = tar::Archive::new(decoder);
-        archive.unpack(&packages_dir).unwrap_or_else(|e| {
-            eprintln!(
-                "\nerror: failed to extract {} {}: {}\n       \
-                 The downloaded file may not be a valid binary package.",
-                name, version, e
-            );
-            std::process::exit(1);
-        });
+        extract_package(&bytes, &packages_dir, name, version);
         std::fs::rename(packages_dir.join(name), package_cache_path(name, version)).unwrap();
 
         // hard-link from cache into project library

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -194,8 +194,16 @@ pub fn build_urls(
     index: &HashMap<String, Package>,
 ) -> Vec<(String, String, String)> {
     let (platform, ext) = get_platform();
-    let r_version = get_r_version();
+    build_urls_with(packages, index, platform, ext, get_r_version())
+}
 
+fn build_urls_with(
+    packages: &[String],
+    index: &HashMap<String, Package>,
+    platform: &str,
+    ext: &str,
+    r_version: &str,
+) -> Vec<(String, String, String)> {
     packages
         .iter()
         .filter_map(|name| {
@@ -417,7 +425,7 @@ mod tests {
     #[test]
     fn test_build_urls_format() {
         let index = make_index(&[("ggplot2", "3.5.1")]);
-        let urls = build_urls(&["ggplot2".to_string()], &index);
+        let urls = build_urls_with(&["ggplot2".to_string()], &index, "macosx/big-sur-arm64", "tgz", "4.4");
         assert_eq!(urls.len(), 1);
         let (name, version, url) = &urls[0];
         assert_eq!(name, "ggplot2");
@@ -442,7 +450,13 @@ mod tests {
     #[test]
     fn test_build_urls_drops_missing_packages() {
         let index = make_index(&[("ggplot2", "3.5.1")]);
-        let urls = build_urls(&["ggplot2".to_string(), "not-in-index".to_string()], &index);
+        let urls = build_urls_with(
+            &["ggplot2".to_string(), "not-in-index".to_string()],
+            &index,
+            "macosx/big-sur-arm64",
+            "tgz",
+            "4.4",
+        );
         assert_eq!(urls.len(), 1);
         assert_eq!(urls[0].0, "ggplot2");
     }
@@ -450,7 +464,7 @@ mod tests {
     #[test]
     fn test_build_urls_empty_input() {
         let index = make_index(&[("ggplot2", "3.5.1")]);
-        let urls = build_urls(&[], &index);
+        let urls = build_urls_with(&[], &index, "macosx/big-sur-arm64", "tgz", "4.4");
         assert!(urls.is_empty());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,12 @@ enum Commands {
         package: String,
     },
     /// Install from ruv.lock (error if lockfile missing or stale)
-    Sync,
+    Sync {
+        /// Skip downloads and use the existing library as-is (for HPC/offline environments).
+        /// Errors if the library directory does not exist yet.
+        #[arg(long)]
+        offline: bool,
+    },
     /// Resolve dependencies from ruv.toml and write ruv.lock
     Lock,
     /// Add a package to ruv.toml and sync
@@ -149,7 +154,7 @@ fn main() {
             write_lockfile(&root_names, &resolved, &index);
         }
 
-        Commands::Sync => {
+        Commands::Sync { offline } => {
             let config = read_config().unwrap_or_else(|e| {
                 eprintln!("error: {e}");
                 std::process::exit(1);
@@ -164,6 +169,25 @@ fn main() {
             if !lockfile_is_fresh(&roots) {
                 eprintln!("error: ruv.lock is missing or out of date — run `ruv lock` first");
                 std::process::exit(1);
+            }
+
+            if offline {
+                if std::path::Path::new(LIB_DIR).exists() {
+                    println!("Offline mode: using existing library at {}", LIB_DIR);
+                    return;
+                } else {
+                    eprintln!("error: --offline requires an existing library at {}", LIB_DIR);
+                    eprintln!(
+                        "       On HPC systems, populate the library on a supported system first:"
+                    );
+                    eprintln!("         1. Run `ruv sync` on a machine with internet access");
+                    eprintln!(
+                        "         2. Copy the {} directory to the HPC node",
+                        LIB_DIR
+                    );
+                    eprintln!("         3. Run `ruv sync --offline` on the HPC node");
+                    std::process::exit(1);
+                }
             }
 
             let t = Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,15 +176,15 @@ fn main() {
                     println!("Offline mode: using existing library at {}", LIB_DIR);
                     return;
                 } else {
-                    eprintln!("error: --offline requires an existing library at {}", LIB_DIR);
+                    eprintln!(
+                        "error: --offline requires an existing library at {}",
+                        LIB_DIR
+                    );
                     eprintln!(
                         "       On HPC systems, populate the library on a supported system first:"
                     );
                     eprintln!("         1. Run `ruv sync` on a machine with internet access");
-                    eprintln!(
-                        "         2. Copy the {} directory to the HPC node",
-                        LIB_DIR
-                    );
+                    eprintln!("         2. Copy the {} directory to the HPC node", LIB_DIR);
                     eprintln!("         3. Run `ruv sync --offline` on the HPC node");
                     std::process::exit(1);
                 }


### PR DESCRIPTION
## Summary

Merges all feature branches developed on `gastown-dev` into `development`. All conflicts were resolved during the gastown-dev integration process.

---

## Branches included

### feat/migrate-renv (PR #72) — `src/renv_migrate.rs`, `src/lockfile.rs`, `src/main.rs`, `src/installer.rs`
Closes #17, #42. Adds `ruv migrate renv` to convert an existing `renv.lock` to `ruv.toml`. Parses renv JSON, extracts R version and CRAN/GitHub sources.

### feat/r-version-file (PR #71) — `src/r_version.rs`, `src/config.rs`, `src/main.rs`
Closes #11. Adds `.r-version` file in the project root as the highest-priority R version constraint, above `ruv.toml` and system R.

### feat/add-remove-lockfile (PR #70) — `src/main.rs`, `src/lockfile.rs`, `src/installer.rs`
Closes #15. `ruv add` now auto-runs `lock` after writing `ruv.toml`. Adds `ruv remove <pkg>` command to remove a package from `ruv.toml`.

### fix/sync-r-version-404 (PR #69) — `src/installer.rs`, `src/lockfile.rs`, `.github/workflows/release.yml`
Fixes #53. Records the R version used at `ruv lock` time into the lockfile and uses that recorded version at `ruv sync` time, preventing 404s when the system R version has changed.

### feat: RHEL/HPC Linux compatibility (PR #59) — `src/installer.rs`, `src/main.rs`, CI
Adds `ruv sync --offline` flag for HPC/air-gapped environments, RHEL `.rpm`-based R auto-download, and `aarch64-unknown-linux-musl` cross-build CI target.

### feat: Windows compatibility (PR #62) — `src/installer.rs`
Adds Windows platform support to RSPM binary URL construction.

### fix: unit tests + gitignore (PR #61) — `src/installer.rs`, `.gitignore`
Fixes `build_urls` unit tests to not invoke R. Adds `.beads/`, `.claude/`, `.runtime/` to `.gitignore`.

### docs/readme-quick-wins (PR #68) + claude/research-pak-features-c7s24 — `README.md`
Rewrites Motivation section, adds Development workflow, `ruv run R` console docs, and corrects pak comparison.

---

## Overlapping areas (resolved on gastown-dev)

The following files were touched by multiple branches — conflicts were already resolved during gastown-dev integration:

| File | Branches |
|------|----------|
| `src/main.rs` | feat/migrate-renv, feat/r-version-file, feat/add-remove-lockfile, RHEL (--offline) |
| `src/installer.rs` | feat/migrate-renv, feat/add-remove-lockfile, fix/sync-r-version-404, RHEL, Windows |
| `src/lockfile.rs` | feat/migrate-renv, feat/add-remove-lockfile, fix/sync-r-version-404 |
| `.github/workflows/release.yml` | fix/sync-r-version-404, Windows (ruv-tjn), RHEL (ruv-1bt) |

**Notable overlap:** `feat/migrate-renv` exists in both `gastown-dev` (merged as 5db6a32) and `development` (merged as PR #72 / 39a9b8d). These carry the same content but different merge commits — no conflicts detected by `git merge-tree`, but worth reviewing during merge.

**R version handling:** `feat/r-version-file` and `fix/sync-r-version-404` both touch R version resolution logic from different angles (source priority vs. lockfile recording). These were integrated together on gastown-dev.

---

## Test plan
- [ ] CI passes on all platforms (Linux x86_64, Linux aarch64, macOS, Windows)
- [ ] `ruv migrate renv` converts a sample `renv.lock` correctly
- [ ] `.r-version` file takes priority over `ruv.toml` r-version
- [ ] `ruv add` auto-locks; `ruv remove` removes from `ruv.toml`
- [ ] `ruv sync` uses lockfile-recorded R version, not system R
- [ ] `ruv sync --offline` works on a pre-populated library

🤖 Generated with [Claude Code](https://claude.com/claude-code)